### PR TITLE
feat: detect and error on schema name collisions across scripts

### DIFF
--- a/SCRIPTING.md
+++ b/SCRIPTING.md
@@ -77,6 +77,17 @@ schema("TypeName", #{
 });
 ```
 
+### Schema name uniqueness
+
+Schema names must be unique across all scripts. If two scripts both call
+`schema("Contact", …)`, the **first script to load wins** (scripts are loaded in
+ascending `load_order` order). The second script will fail to load and an error will
+be shown in the Scripts manager.
+
+> **Note:** A single script is allowed to call `schema()` with the same name more than
+> once — the last call in the script wins and no error is raised. Avoid doing this
+> intentionally; it is unsupported and the behaviour may change.
+
 ### Field definition
 
 Each entry in `fields` is a map:
@@ -768,6 +779,21 @@ schema("ProjectFolder", #{
 
 Note: this count only increases on add. It does not decrease when notes are deleted or
 moved away. For a live accurate count use `on_view` with `get_children()` instead.
+
+### Avoiding accidental schema collisions
+
+Schema names are checked for uniqueness across scripts at load time. If you copy a
+schema definition from one script into another, disable the original script, and then
+re-enable it later, the re-enabled script will fail to load because the name is now
+claimed by the other script.
+
+The safest rule: **one schema per script that defines it.** Do not copy `schema()`
+blocks between scripts; factor shared logic into helper functions or separate the
+schemas into their own scripts instead.
+
+One edge case to be aware of: calling `schema()` with the same name **twice inside
+the same script** is not an error — the second call overwrites the first silently.
+This is unlikely to be intentional and should be avoided.
 
 ---
 

--- a/docs/plans/2026-02-25-script-collision-detection-design.md
+++ b/docs/plans/2026-02-25-script-collision-detection-design.md
@@ -1,0 +1,47 @@
+# Script Collision Detection — Design
+
+**Date:** 2026-02-25
+**Issue:** #6
+**Branch:** `feat/script-collision-detection`
+
+## Problem
+
+When two scripts both call `schema("Contact", ...)`, the second silently overwrites the first. There is no detection, no error, and no user feedback. The winner is whoever happens to load last, which is non-deterministic from the user's perspective.
+
+## Approach
+
+### First-Script Wins, Second Gets an Error
+
+When `schema()` is called during script loading, check whether that schema name is already registered. If it is, return a Rhai error. The error propagates out of `load_script()` and is collected.
+
+Scripts already execute in deterministic order: `load_order ASC, created_at ASC`. So "first" is well-defined and stable.
+
+### Owner Tracking
+
+To produce a helpful error message ("already defined by 'Script A'"), the registry must remember which script registered each schema. A `schema_owners: HashMap<String, String>` (schema name → script name) is added to `ScriptRegistry` alongside the existing `schemas` map.
+
+### Error Collection and Surfacing
+
+`reload_scripts()` currently swallows errors to `eprintln!`. The approach:
+- `reload_scripts()` returns `Vec<ScriptError>` (collected from all failed scripts)
+- Workspace mutation methods (`update_user_script`, `delete_user_script`, etc.) bundle those errors into their return value
+- Tauri commands pass them through so the frontend can display a toast/alert at the moment of saving
+
+### Error Type
+
+```rust
+#[derive(Debug, Clone, Serialize)]
+pub struct ScriptError {
+    pub script_name: String,
+    pub message: String,
+}
+```
+
+### No Partial Schema Registration
+
+If a script's `schema()` call fails due to collision, the error is returned from the Rhai host function immediately. No schema, hooks, or any other state from that call is registered. The `load_script()` function already clears `current_loading_ast` on error, preventing stale hook entries.
+
+## Decisions Not Made
+
+- **UI display format:** Decided by the frontend team; the backend just returns `Vec<ScriptError>`.
+- **Starter script collisions:** Starter scripts are bundled and controlled by the app — they should not collide in practice. No special handling needed now.

--- a/docs/plans/2026-02-25-script-collision-detection.md
+++ b/docs/plans/2026-02-25-script-collision-detection.md
@@ -1,0 +1,119 @@
+# Script Collision Detection — Implementation Plan
+
+**Date:** 2026-02-25
+**Issue:** #6
+**Branch:** `feat/script-collision-detection`
+**Design doc:** `2026-02-25-script-collision-detection-design.md`
+
+## Tasks
+
+### 1. Add `ScriptError` type — `krillnotes-core/src/core/scripting/mod.rs`
+
+Add near the top of the file:
+```rust
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ScriptError {
+    pub script_name: String,
+    pub message: String,
+}
+```
+
+### 2. Add `schema_owners` to `ScriptRegistry` — `scripting/mod.rs`
+
+Add field to struct:
+```rust
+schema_owners: Arc<Mutex<HashMap<String, String>>>,
+```
+
+Initialize in `new()`:
+```rust
+let schema_owners: Arc<Mutex<HashMap<String, String>>> = Arc::new(Mutex::new(HashMap::new()));
+```
+
+Clear in `clear_all()`:
+```rust
+self.schema_owners.lock().unwrap().clear();
+```
+
+### 3. Collision detection in `schema()` host fn — `scripting/mod.rs` line 76
+
+Before line 79 (`schemas_arc...insert`), add:
+```rust
+// Collision check: first script to register a name wins.
+{
+    let owners = schema_owners_arc.lock().unwrap();
+    if let Some(owner) = owners.get(&name) {
+        return Err(format!(
+            "Schema '{}' is already defined by script '{}'. Schema names must be unique.",
+            name, owner
+        ).into());
+    }
+}
+schema_owners_arc.lock().unwrap().insert(name.clone(), script_name.clone());
+```
+
+Requires cloning `schema_name_arc` into the closure as `schema_owners_arc` and `schema_name_arc`.
+
+### 4. `reload_scripts()` collects errors — `workspace.rs`
+
+Change signature to return errors:
+```rust
+fn reload_scripts(&mut self) -> Result<Vec<ScriptError>> {
+    self.script_registry.clear_all();
+    let scripts = self.list_user_scripts()?;
+    let mut errors = Vec::new();
+    for script in scripts.iter().filter(|s| s.enabled) {
+        if let Err(e) = self.script_registry.load_script(&script.source_code, &script.name) {
+            errors.push(ScriptError {
+                script_name: script.name.clone(),
+                message: e.to_string(),
+            });
+        }
+    }
+    Ok(errors)
+}
+```
+
+### 5. Workspace mutation methods return errors
+
+Change return types to include `Vec<ScriptError>`:
+- `create_user_script` → `Result<(UserScript, Vec<ScriptError>)>`
+- `update_user_script` → `Result<(UserScript, Vec<ScriptError>)>`
+- `delete_user_script` → `Result<Vec<ScriptError>>`
+- `toggle_user_script` → `Result<Vec<ScriptError>>`
+- `reorder_user_script` → `Result<Vec<ScriptError>>`
+- `reorder_all_user_scripts` → `Result<Vec<ScriptError>>`
+
+### 6. Re-export `ScriptError` — `krillnotes-core/src/lib.rs`
+
+Add to the `pub use core::scripting::{ ... }` block.
+
+### 7. Update Tauri commands — `krillnotes-desktop/src-tauri/src/lib.rs`
+
+New return types for Tauri commands:
+- `create_user_script` → `Result<ScriptMutationResult<UserScript>, String>`
+- `update_user_script` → `Result<ScriptMutationResult<UserScript>, String>`
+- `delete_user_script` → `Result<Vec<ScriptError>, String>`
+- `toggle_user_script` → `Result<Vec<ScriptError>, String>`
+- `reorder_user_script` → `Result<Vec<ScriptError>, String>`
+
+Where:
+```rust
+#[derive(Serialize)]
+struct ScriptMutationResult<T: Serialize> {
+    data: T,
+    errors: Vec<ScriptError>,
+}
+```
+
+### 8. Write a test — `krillnotes-core`
+
+Add a test that:
+1. Creates two scripts that both define `schema("TestCollision", ...)`
+2. Calls `reload_scripts()`
+3. Asserts that `Vec<ScriptError>` has exactly one error referencing the second script
+4. Asserts the first script's schema is still registered
+
+### 9. `cargo test` and `cargo build`
+
+Verify all 3 existing tests pass and the project builds.

--- a/krillnotes-core/src/lib.rs
+++ b/krillnotes-core/src/lib.rs
@@ -21,7 +21,7 @@ pub use core::{
     note::{FieldValue, Note},
     operation::Operation,
     operation_log::{OperationLog, OperationSummary, PurgeStrategy},
-    scripting::{FieldDefinition, HookRegistry, QueryContext, Schema, ScriptRegistry, StarterScript},
+    scripting::{FieldDefinition, HookRegistry, QueryContext, Schema, ScriptError, ScriptRegistry, StarterScript},
     storage::Storage,
     user_script::UserScript,
     workspace::{AddPosition, Workspace},

--- a/krillnotes-desktop/src/types.ts
+++ b/krillnotes-desktop/src/types.ts
@@ -74,6 +74,16 @@ export interface UserScript {
   modifiedAt: number;
 }
 
+export interface ScriptError {
+  scriptName: string;
+  message: string;
+}
+
+export interface ScriptMutationResult<T> {
+  data: T;
+  loadErrors: ScriptError[];
+}
+
 export interface DropIndicator {
   noteId: string;
   position: 'before' | 'after' | 'child';


### PR DESCRIPTION
## Summary

- When two scripts define the same schema name, the **first script to load wins** (by `load_order ASC`) and the second fails with a clear error naming both the contested schema and the owning script
- Load errors from any script mutation (save, toggle, delete, reorder) are now returned to the frontend and shown in the Scripts manager error banner
- Documents the collision behaviour and the same-script self-redefine edge case in `SCRIPTING.md`

## What changed

**Rust / core**
- `ScriptError { script_name, message }` type added and re-exported from crate root
- `ScriptRegistry` tracks schema ownership via a `schema_owners` HashMap; collision check fires in the `schema()` Rhai host function (same-script re-registration is allowed so update pre-validation doesn't false-fire)
- `reload_scripts()` collects and returns `Vec<ScriptError>` instead of swallowing errors
- All workspace mutation methods return load errors alongside their primary result
- Tauri commands surface errors via `ScriptMutationResult<T>` (create/update) or `Vec<ScriptError>` directly (delete/toggle/reorder)

**Frontend**
- `ScriptError` and `ScriptMutationResult<T>` types added to `types.ts`
- All five mutation handlers in `ScriptManagerDialog` capture and display load errors

## Test plan

- [x] 169 existing tests pass, 3 new collision-detection tests added
- [x] `cargo build` clean
- [x] `tsc --noEmit` clean
- [x] Manual: save a script that defines a schema already owned by another script → error shown
- [x] Manual: toggle a script on/off when a collision exists → error shown in list view
- [x] Manual: reorder scripts so the colliding one loads first → collision transfers to the other script

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)