### PR TITLE
fix: import password dialog hidden behind name dialog

### DIFF
--- a/krillnotes-desktop/src/App.tsx
+++ b/krillnotes-desktop/src/App.tsx
@@ -168,6 +168,7 @@ function App() {
         zipPassword: pendingImportPassword ?? undefined,
       });
       setImporting(false);
+      setImportState(null);
       setShowImportWorkspacePasswordDialog(true);
     } catch (error) {
       setImportError(`${error}`);


### PR DESCRIPTION
## Summary
- Clears `importState` before opening `SetPasswordDialog` during workspace import
- Prevents both dialogs from rendering simultaneously at `z-50`, which caused the password dialog to appear hidden behind the name dialog

## Root cause
In `handleImportConfirm`, `setShowImportWorkspacePasswordDialog(true)` was called without first calling `setImportState(null)`. Both dialogs use `fixed inset-0 z-50` overlays, so they stacked on top of each other with the name dialog on top.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)