### PR TITLE
fix: rename app to Krillnotes and adopt .krillnotes file format

### DIFF
--- a/krillnotes-desktop/src-tauri/tauri.conf.json
+++ b/krillnotes-desktop/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "krillnotes-desktop",
+  "productName": "Krillnotes",
   "version": "0.2.2",
-  "identifier": "com.careck.krillnotes-desktop",
+  "identifier": "com.careck.krillnotes",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "krillnotes-desktop",
+        "title": "Krillnotes",
         "width": 800,
         "height": 600,
         "dragDropEnabled": false

--- a/krillnotes-desktop/src/App.tsx
+++ b/krillnotes-desktop/src/App.tsx
@@ -49,7 +49,7 @@ const createMenuHandlers = (
   'File > Import Workspace clicked': async () => {
     try {
       const zipPath = await open({
-        filters: [{ name: 'Krillnotes Export', extensions: ['zip'] }],
+        filters: [{ name: 'Krillnotes Export', extensions: ['krillnotes'] }],
         multiple: false,
         title: 'Import Workspace',
       });
@@ -210,8 +210,8 @@ function App() {
 
     try {
       const path = await save({
-        filters: [{ name: 'Krillnotes Export', extensions: ['zip'] }],
-        defaultPath: `${(workspace?.filename ?? 'workspace').replace(/\.db$/, '')}.krillnotes.zip`,
+        filters: [{ name: 'Krillnotes Export', extensions: ['krillnotes'] }],
+        defaultPath: `${(workspace?.filename ?? 'workspace').replace(/\.db$/, '')}.krillnotes`,
         title: 'Export Workspace',
       });
 


### PR DESCRIPTION
## Summary

- `productName`, bundle identifier, and window title updated from `krillnotes-desktop` → `Krillnotes` / `com.careck.krillnotes`
- Export and import file dialogs now filter for `.krillnotes` instead of `.zip`
- Default export filename drops the redundant `.zip` suffix (e.g. `my-workspace.krillnotes` instead of `my-workspace.krillnotes.zip`)
- The archive format is unchanged — still a standard zip under the hood

## Notes

- Changing the bundle identifier means Tauri-managed app state (window position, etc.) won't carry over from previous installs. Workspace `.db` files are unaffected.

## Test plan

- [x] App bundle is named `Krillnotes.app` after build
- [x] Window title bar shows "Krillnotes"
- [x] Export save dialog defaults to `.krillnotes` extension
- [x] Import open dialog filters for `.krillnotes` files
- [x] Exported `.krillnotes` files can be re-imported successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)