### PR TITLE
fix: disable workspace menu items until a workspace is open (#32)

### DIFF
--- a/krillnotes-desktop/src-tauri/src/menu.rs
+++ b/krillnotes-desktop/src-tauri/src/menu.rs
@@ -8,6 +8,10 @@ pub struct MenuResult<R: Runtime> {
     pub menu: Menu<R>,
     pub paste_as_child: MenuItem<R>,
     pub paste_as_sibling: MenuItem<R>,
+    /// Workspace-specific items that start disabled and are enabled when a
+    /// workspace window opens. Includes Add Note, Delete Note, Copy Note,
+    /// Manage Scripts, Operations Log, and Export Workspace.
+    pub workspace_items: Vec<MenuItem<R>>,
 }
 
 /// Return type of [`build_edit_menu`], exposing the paste handles alongside the submenu.
@@ -15,6 +19,19 @@ struct EditMenuResult<R: Runtime> {
     submenu: Submenu<R>,
     paste_as_child: MenuItem<R>,
     paste_as_sibling: MenuItem<R>,
+    workspace_items: Vec<MenuItem<R>>,
+}
+
+/// Return type of [`build_file_menu`].
+struct FileMenuResult<R: Runtime> {
+    submenu: Submenu<R>,
+    workspace_items: Vec<MenuItem<R>>,
+}
+
+/// Return type of [`build_tools_menu`].
+struct ToolsMenuResult<R: Runtime> {
+    submenu: Submenu<R>,
+    workspace_items: Vec<MenuItem<R>>,
 }
 
 /// Builds the application menu using platform-conditional assembly.
@@ -22,27 +39,37 @@ struct EditMenuResult<R: Runtime> {
 /// On macOS: App menu (Krillnotes), File, Edit, Tools, View.
 /// On other platforms: File, Edit, Tools, View, Help.
 ///
+/// Workspace-specific items are built with `enabled(false)` and their handles
+/// are returned in [`MenuResult::workspace_items`] so the caller can enable
+/// them when a workspace window opens.
+///
 /// Returns a [`MenuResult`] with the assembled menu and paste item handles.
 ///
 /// # Errors
 ///
 /// Returns [`tauri::Error`] if any menu item or submenu fails to build.
 pub fn build_menu<R: Runtime>(app: &AppHandle<R>) -> Result<MenuResult<R>, tauri::Error> {
-    let file_menu = build_file_menu(app)?;
+    let file_result = build_file_menu(app)?;
     let edit_result = build_edit_menu(app)?;
-    let tools_menu = build_tools_menu(app)?;
+    let tools_result = build_tools_menu(app)?;
     let view_menu = build_view_menu(app)?;
+
+    let mut workspace_items = Vec::new();
+    workspace_items.extend(file_result.workspace_items);
+    workspace_items.extend(edit_result.workspace_items);
+    workspace_items.extend(tools_result.workspace_items);
 
     #[cfg(target_os = "macos")]
     {
         let app_menu = build_macos_app_menu(app)?;
         let menu = MenuBuilder::new(app)
-            .items(&[&app_menu, &file_menu, &edit_result.submenu, &tools_menu, &view_menu])
+            .items(&[&app_menu, &file_result.submenu, &edit_result.submenu, &tools_result.submenu, &view_menu])
             .build()?;
         return Ok(MenuResult {
             menu,
             paste_as_child: edit_result.paste_as_child,
             paste_as_sibling: edit_result.paste_as_sibling,
+            workspace_items,
         });
     }
 
@@ -50,12 +77,13 @@ pub fn build_menu<R: Runtime>(app: &AppHandle<R>) -> Result<MenuResult<R>, tauri
     {
         let help_menu = build_help_menu(app)?;
         let menu = MenuBuilder::new(app)
-            .items(&[&file_menu, &edit_result.submenu, &tools_menu, &view_menu, &help_menu])
+            .items(&[&file_result.submenu, &edit_result.submenu, &tools_result.submenu, &view_menu, &help_menu])
             .build()?;
         return Ok(MenuResult {
             menu,
             paste_as_child: edit_result.paste_as_child,
             paste_as_sibling: edit_result.paste_as_sibling,
+            workspace_items,
         });
     }
 }
@@ -81,32 +109,39 @@ fn build_view_menu<R: Runtime>(app: &AppHandle<R>) -> Result<Submenu<R>, tauri::
 
 /// Builds the Tools submenu (Manage Scripts, Operations Log).
 ///
-/// Item IDs are kept identical to their previous locations so that existing
-/// frontend event-routing code continues to work without changes.
+/// Both items require an active workspace and are built with `enabled(false)`.
 ///
 /// # Errors
 ///
 /// Returns [`tauri::Error`] if any menu item fails to build.
-fn build_tools_menu<R: Runtime>(app: &AppHandle<R>) -> Result<Submenu<R>, tauri::Error> {
-    SubmenuBuilder::new(app, "Tools")
-        .items(&[
-            &MenuItemBuilder::with_id("edit_manage_scripts", "Manage Scripts...")
-                .build(app)?,
-            &MenuItemBuilder::with_id("view_operations_log", "Operations Log...")
-                .build(app)?,
-        ])
-        .build()
+fn build_tools_menu<R: Runtime>(app: &AppHandle<R>) -> Result<ToolsMenuResult<R>, tauri::Error> {
+    let manage_scripts = MenuItemBuilder::with_id("edit_manage_scripts", "Manage Scripts...")
+        .enabled(false)
+        .build(app)?;
+    let operations_log = MenuItemBuilder::with_id("view_operations_log", "Operations Log...")
+        .enabled(false)
+        .build(app)?;
+
+    let submenu = SubmenuBuilder::new(app, "Tools")
+        .items(&[&manage_scripts, &operations_log])
+        .build()?;
+
+    Ok(ToolsMenuResult {
+        submenu,
+        workspace_items: vec![manage_scripts, operations_log],
+    })
 }
 
 /// Builds the File submenu.
 ///
+/// Export Workspace requires an active workspace and is built with `enabled(false)`.
 /// On macOS, Quit is intentionally absent — it belongs in the Krillnotes app menu.
 /// On all other platforms, Quit is included at the bottom of File.
 ///
 /// # Errors
 ///
 /// Returns [`tauri::Error`] if any menu item fails to build.
-fn build_file_menu<R: Runtime>(app: &AppHandle<R>) -> Result<Submenu<R>, tauri::Error> {
+fn build_file_menu<R: Runtime>(app: &AppHandle<R>) -> Result<FileMenuResult<R>, tauri::Error> {
     let new_item = MenuItemBuilder::with_id("file_new", "New Workspace")
         .accelerator("CmdOrCtrl+N")
         .build(app)?;
@@ -114,7 +149,9 @@ fn build_file_menu<R: Runtime>(app: &AppHandle<R>) -> Result<Submenu<R>, tauri::
         .accelerator("CmdOrCtrl+O")
         .build(app)?;
     let sep1 = PredefinedMenuItem::separator(app)?;
-    let export_item = MenuItemBuilder::with_id("file_export", "Export Workspace...").build(app)?;
+    let export_item = MenuItemBuilder::with_id("file_export", "Export Workspace...")
+        .enabled(false)
+        .build(app)?;
     let import_item = MenuItemBuilder::with_id("file_import", "Import Workspace...").build(app)?;
     let sep2 = PredefinedMenuItem::separator(app)?;
     let close_item = PredefinedMenuItem::close_window(app, None)?;
@@ -128,13 +165,19 @@ fn build_file_menu<R: Runtime>(app: &AppHandle<R>) -> Result<Submenu<R>, tauri::
         builder.item(&quit_item)
     };
 
-    builder.build()
+    let submenu = builder.build()?;
+    Ok(FileMenuResult {
+        submenu,
+        workspace_items: vec![export_item],
+    })
 }
 
 /// Builds the Edit submenu.
 ///
-/// On macOS, Settings is intentionally absent — it belongs in the Krillnotes app menu.
-/// On all other platforms, Settings... (⌘,) is included between the first separator and the undo/redo block.
+/// Add Note, Delete Note, and Copy Note require an active workspace and are
+/// built with `enabled(false)`. On macOS, Settings is intentionally absent —
+/// it belongs in the Krillnotes app menu. On all other platforms, Settings...
+/// (⌘,) is included between the first separator and the undo/redo block.
 ///
 /// # Errors
 ///
@@ -142,12 +185,15 @@ fn build_file_menu<R: Runtime>(app: &AppHandle<R>) -> Result<Submenu<R>, tauri::
 fn build_edit_menu<R: Runtime>(app: &AppHandle<R>) -> Result<EditMenuResult<R>, tauri::Error> {
     let add_note = MenuItemBuilder::with_id("edit_add_note", "Add Note")
         .accelerator("CmdOrCtrl+Shift+N")
+        .enabled(false)
         .build(app)?;
     let delete_note = MenuItemBuilder::with_id("edit_delete_note", "Delete Note")
         .accelerator("CmdOrCtrl+Backspace")
+        .enabled(false)
         .build(app)?;
     let sep1 = PredefinedMenuItem::separator(app)?;
     let copy_note = MenuItemBuilder::with_id("edit_copy_note", "Copy Note")
+        .enabled(false)
         .build(app)?;
     let paste_child = MenuItemBuilder::with_id("edit_paste_as_child", "Paste as Child")
         .enabled(false)
@@ -178,6 +224,7 @@ fn build_edit_menu<R: Runtime>(app: &AppHandle<R>) -> Result<EditMenuResult<R>, 
         submenu,
         paste_as_child: paste_child,
         paste_as_sibling: paste_sibling,
+        workspace_items: vec![add_note, delete_note, copy_note],
     })
 }
 


### PR DESCRIPTION
## Summary

- Workspace-specific menu items (Add Note, Delete Note, Copy Note, Manage Scripts, Operations Log, Export Workspace) now start **disabled** and are only enabled when a workspace window opens
- On macOS, item handles are stored in `AppState` under `"macos"` (global menu bar) and toggled as workspace windows open/close
- On Windows, each workspace window's private menu has items enabled in-place before the menu is attached

## Items affected

| Item | Menu |
|---|---|
| Add Note | Edit |
| Delete Note | Edit |
| Copy Note | Edit |
| Manage Scripts | Tools |
| Operations Log | Tools |
| Export Workspace | File |

Paste items (Paste as Child / Paste as Sibling) were already `enabled(false)` and continue to be managed separately by `set_paste_menu_enabled`.

## Test plan

- [x] Launch app — all workspace items are greyed out on the start window
- [x] Open or create a workspace — all workspace items become active
- [x] Close the workspace window (macOS) — items grey out again if no other workspace is open

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)