### PR TITLE
feat: workspace metadata editor for template gallery (issue #37)

### DIFF
--- a/krillnotes-core/src/lib.rs
+++ b/krillnotes-core/src/lib.rs
@@ -14,7 +14,7 @@ pub use core::{
     delete::{DeleteResult, DeleteStrategy},
     export::{
         export_workspace, import_workspace, peek_import, ExportError, ExportNotes, ImportResult,
-        ScriptManifest, ScriptManifestEntry, APP_VERSION,
+        ScriptManifest, ScriptManifestEntry, WorkspaceMetadata, APP_VERSION,
     },
     device::get_device_id,
     error::{KrillnotesError, Result},

--- a/krillnotes-desktop/src-tauri/src/lib.rs
+++ b/krillnotes-desktop/src-tauri/src/lib.rs
@@ -656,6 +656,35 @@ fn get_all_tags(
 }
 
 #[tauri::command]
+fn get_workspace_metadata(
+    window: tauri::Window,
+    state: State<'_, AppState>,
+) -> std::result::Result<WorkspaceMetadata, String> {
+    let label = window.label();
+    let workspaces = state.workspaces.lock()
+        .expect("Mutex poisoned");
+    let workspace = workspaces.get(label)
+        .ok_or("No workspace open")?;
+    workspace.get_workspace_metadata()
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn set_workspace_metadata(
+    window: tauri::Window,
+    state: State<'_, AppState>,
+    metadata: WorkspaceMetadata,
+) -> std::result::Result<(), String> {
+    let label = window.label();
+    let mut workspaces = state.workspaces.lock()
+        .expect("Mutex poisoned");
+    let workspace = workspaces.get_mut(label)
+        .ok_or("No workspace open")?;
+    workspace.set_workspace_metadata(&metadata)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 fn get_notes_for_tag(
     window: tauri::Window,
     state: State<'_, AppState>,
@@ -1268,6 +1297,7 @@ const MENU_MESSAGES: &[(&str, &str)] = &[
     ("edit_copy_note",        "Edit > Copy Note clicked"),
     ("edit_paste_as_child",   "Edit > Paste as Child clicked"),
     ("edit_paste_as_sibling", "Edit > Paste as Sibling clicked"),
+    ("workspace_properties",  "Edit > Workspace Properties clicked"),
 ];
 
 /// Translates a native [`tauri::menu::MenuEvent`] into a `"menu-action"` event
@@ -1405,6 +1435,8 @@ pub fn run() {
             update_note_tags,
             get_all_tags,
             get_notes_for_tag,
+            get_workspace_metadata,
+            set_workspace_metadata,
             get_note,
             search_notes,
             count_children,

--- a/krillnotes-desktop/src-tauri/src/menu.rs
+++ b/krillnotes-desktop/src-tauri/src/menu.rs
@@ -202,21 +202,26 @@ fn build_edit_menu<R: Runtime>(app: &AppHandle<R>) -> Result<EditMenuResult<R>, 
         .enabled(false)
         .build(app)?;
     let sep2 = PredefinedMenuItem::separator(app)?;
+    let workspace_properties = MenuItemBuilder::with_id("workspace_properties", "Workspace Properties\u{2026}")
+        .enabled(false)
+        .build(app)?;
+    let sep3 = PredefinedMenuItem::separator(app)?;
     let undo = PredefinedMenuItem::undo(app, None)?;
     let redo = PredefinedMenuItem::redo(app, None)?;
     let copy = PredefinedMenuItem::copy(app, None)?;
     let paste = PredefinedMenuItem::paste(app, None)?;
 
     let builder = SubmenuBuilder::new(app, "Edit")
-        .items(&[&add_note, &delete_note, &sep1, &copy_note, &paste_child, &paste_sibling, &sep2]);
+        .items(&[&add_note, &delete_note, &sep1, &copy_note, &paste_child, &paste_sibling,
+                 &sep2, &workspace_properties, &sep3]);
 
     #[cfg(not(target_os = "macos"))]
     let builder = {
         let settings = MenuItemBuilder::with_id("edit_settings", "Settings...")
             .accelerator("CmdOrCtrl+,")
             .build(app)?;
-        let sep3 = PredefinedMenuItem::separator(app)?;
-        builder.item(&settings).item(&sep3)
+        let sep4 = PredefinedMenuItem::separator(app)?;
+        builder.item(&settings).item(&sep4)
     };
 
     let submenu = builder.items(&[&undo, &redo, &copy, &paste]).build()?;
@@ -224,7 +229,7 @@ fn build_edit_menu<R: Runtime>(app: &AppHandle<R>) -> Result<EditMenuResult<R>, 
         submenu,
         paste_as_child: paste_child,
         paste_as_sibling: paste_sibling,
-        workspace_items: vec![add_note, delete_note, copy_note],
+        workspace_items: vec![add_note, delete_note, copy_note, workspace_properties],
     })
 }
 

--- a/krillnotes-desktop/src/components/WorkspacePropertiesDialog.tsx
+++ b/krillnotes-desktop/src/components/WorkspacePropertiesDialog.tsx
@@ -1,0 +1,233 @@
+import { useState, useEffect } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import type { WorkspaceMetadata } from '../types';
+
+const PREDEFINED_LICENSES = [
+  'CC BY 4.0',
+  'CC BY-SA 4.0',
+  'CC BY-NC 4.0',
+  'CC0 1.0',
+  'MIT',
+  'Apache 2.0',
+  'All Rights Reserved',
+  'Other\u2026',
+] as const;
+
+const OTHER_LICENSE = 'Other\u2026';
+
+const LICENSE_URLS: Partial<Record<string, string>> = {
+  'CC BY 4.0':          'https://creativecommons.org/licenses/by/4.0/',
+  'CC BY-SA 4.0':       'https://creativecommons.org/licenses/by-sa/4.0/',
+  'CC BY-NC 4.0':       'https://creativecommons.org/licenses/by-nc/4.0/',
+  'CC0 1.0':            'https://creativecommons.org/publicdomain/zero/1.0/',
+  'MIT':                'https://opensource.org/licenses/MIT',
+  'Apache 2.0':         'https://www.apache.org/licenses/LICENSE-2.0',
+  'All Rights Reserved': '',
+};
+
+interface WorkspacePropertiesDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function WorkspacePropertiesDialog({ isOpen, onClose }: WorkspacePropertiesDialogProps) {
+  const [authorName, setAuthorName] = useState('');
+  const [authorOrg, setAuthorOrg] = useState('');
+  const [homepageUrl, setHomepageUrl] = useState('');
+  const [description, setDescription] = useState('');
+  const [licenseSelect, setLicenseSelect] = useState('');
+  const [licenseCustom, setLicenseCustom] = useState('');
+  const [licenseUrl, setLicenseUrl] = useState('');
+  const [language, setLanguage] = useState('');
+  const [tagsRaw, setTagsRaw] = useState('');
+  const [error, setError] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    invoke<WorkspaceMetadata>('get_workspace_metadata')
+      .then(meta => {
+        setAuthorName(meta.authorName ?? '');
+        setAuthorOrg(meta.authorOrg ?? '');
+        setHomepageUrl(meta.homepageUrl ?? '');
+        setDescription(meta.description ?? '');
+        setLicenseUrl(meta.licenseUrl ?? '');
+        setLanguage(meta.language ?? '');
+        setTagsRaw(meta.tags.join(', '));
+        setError('');
+
+        const lic = meta.license ?? '';
+        if (PREDEFINED_LICENSES.includes(lic as typeof PREDEFINED_LICENSES[number]) && lic !== OTHER_LICENSE) {
+          setLicenseSelect(lic);
+          setLicenseCustom('');
+        } else if (lic !== '') {
+          setLicenseSelect(OTHER_LICENSE);
+          setLicenseCustom(lic);
+        } else {
+          setLicenseSelect('');
+          setLicenseCustom('');
+        }
+      })
+      .catch(err => setError(`Failed to load workspace properties: ${err}`));
+  }, [isOpen]);
+
+  // Auto-fill license URL when a predefined license is selected.
+  useEffect(() => {
+    if (licenseSelect && licenseSelect !== OTHER_LICENSE) {
+      setLicenseUrl(LICENSE_URLS[licenseSelect] ?? '');
+    }
+  }, [licenseSelect]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const resolvedLicense = licenseSelect === OTHER_LICENSE ? licenseCustom : licenseSelect;
+
+  const parseTags = (raw: string): string[] =>
+    raw.split(',').map(t => t.trim()).filter(t => t.length > 0);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError('');
+    try {
+      const metadata: WorkspaceMetadata = {
+        version: 1,
+        authorName: authorName || undefined,
+        authorOrg: authorOrg || undefined,
+        homepageUrl: homepageUrl || undefined,
+        description: description || undefined,
+        license: resolvedLicense || undefined,
+        licenseUrl: licenseUrl || undefined,
+        language: language || undefined,
+        tags: parseTags(tagsRaw),
+      };
+      await invoke('set_workspace_metadata', { metadata });
+      onClose();
+    } catch (err) {
+      setError(`Failed to save workspace properties: ${err}`);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const field = (label: string, children: React.ReactNode) => (
+    <div className="mb-3">
+      <label className="block text-sm font-medium mb-1">{label}</label>
+      {children}
+    </div>
+  );
+
+  const inputClass = 'w-full bg-secondary border border-secondary rounded px-3 py-1.5 text-sm';
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-background border border-secondary p-6 rounded-lg w-[520px] max-h-[85vh] overflow-y-auto">
+        <h2 className="text-xl font-bold mb-4">Workspace Properties</h2>
+        <p className="text-sm text-muted-foreground mb-4">
+          This information is embedded in the exported <code>.krillnotes</code> archive and can be
+          used by template galleries to display information about this workspace.
+        </p>
+
+        {field('Author Name', (
+          <input type="text" value={authorName} onChange={e => setAuthorName(e.target.value)}
+            className={inputClass} placeholder="e.g. Jane Smith"
+            autoCorrect="off" autoCapitalize="off" spellCheck={false} />
+        ))}
+
+        {field('Author Organisation', (
+          <input type="text" value={authorOrg} onChange={e => setAuthorOrg(e.target.value)}
+            className={inputClass} placeholder="e.g. ACME Corp"
+            autoCorrect="off" autoCapitalize="off" spellCheck={false} />
+        ))}
+
+        {field('Homepage URL', (
+          <input type="text" value={homepageUrl} onChange={e => setHomepageUrl(e.target.value)}
+            className={inputClass} placeholder="https://example.com"
+            autoCorrect="off" autoCapitalize="off" spellCheck={false} />
+        ))}
+
+        {field('Description', (
+          <textarea value={description} onChange={e => setDescription(e.target.value)}
+            className={`${inputClass} resize-y min-h-[80px]`}
+            placeholder="A short description of this workspace template…"
+            spellCheck={false} />
+        ))}
+
+        {field('Language', (
+          <input type="text" value={language} onChange={e => setLanguage(e.target.value)}
+            className={inputClass} placeholder="e.g. en"
+            autoCorrect="off" autoCapitalize="off" spellCheck={false} />
+        ))}
+
+        {field('License', (
+          <div className="flex flex-col gap-1.5">
+            <select value={licenseSelect} onChange={e => setLicenseSelect(e.target.value)}
+              className={`${inputClass} bg-background`}>
+              <option value="">— select a license —</option>
+              {PREDEFINED_LICENSES.map(l => (
+                <option key={l} value={l}>{l}</option>
+              ))}
+            </select>
+            {licenseSelect === OTHER_LICENSE && (
+              <input type="text" value={licenseCustom} onChange={e => setLicenseCustom(e.target.value)}
+                className={inputClass} placeholder="Enter license name…"
+                autoCorrect="off" autoCapitalize="off" spellCheck={false} />
+            )}
+          </div>
+        ))}
+
+        {field('License URL', (() => {
+          const isPredefined = licenseSelect !== '' && licenseSelect !== OTHER_LICENSE;
+          return (
+            <input type="text" value={licenseUrl}
+              onChange={e => setLicenseUrl(e.target.value)}
+              readOnly={isPredefined}
+              className={`${inputClass} ${isPredefined ? 'opacity-50 cursor-default' : ''}`}
+              placeholder="https://creativecommons.org/licenses/by/4.0/"
+              autoCorrect="off" autoCapitalize="off" spellCheck={false} />
+          );
+        })())}
+
+        {field('Workspace Tags', (
+          <>
+            <input type="text" value={tagsRaw} onChange={e => setTagsRaw(e.target.value)}
+              className={inputClass} placeholder="e.g. productivity, zettelkasten, notes"
+              autoCorrect="off" autoCapitalize="off" spellCheck={false} />
+            <p className="text-xs text-muted-foreground mt-1">
+              Comma-separated tags for gallery discovery. These are separate from per-note tags.
+            </p>
+          </>
+        ))}
+
+        {error && (
+          <div className="mb-4 p-3 bg-red-500/10 border border-red-500/20 text-red-500 rounded text-sm">
+            {error}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2 mt-4">
+          <button onClick={onClose}
+            className="px-4 py-2 border border-secondary rounded hover:bg-secondary"
+            disabled={saving}>
+            Cancel
+          </button>
+          <button onClick={handleSave}
+            className="px-4 py-2 bg-primary text-primary-foreground rounded hover:bg-primary/90"
+            disabled={saving}>
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default WorkspacePropertiesDialog;

--- a/krillnotes-desktop/src/components/WorkspaceView.tsx
+++ b/krillnotes-desktop/src/components/WorkspaceView.tsx
@@ -10,6 +10,7 @@ import DeleteConfirmDialog from './DeleteConfirmDialog';
 import HoverTooltip from './HoverTooltip';
 import ScriptManagerDialog from './ScriptManagerDialog';
 import OperationsLogDialog from './OperationsLogDialog';
+import WorkspacePropertiesDialog from './WorkspacePropertiesDialog';
 import type { Note, TreeNode, WorkspaceInfo, DeleteResult, SchemaInfo, DropIndicator } from '../types';
 import { DeleteStrategy } from '../types';
 import { buildTree, flattenVisibleTree, findNoteInTree, getAncestorIds, getDescendantIds } from '../utils/tree';
@@ -54,6 +55,9 @@ function WorkspaceView({ workspaceInfo }: WorkspaceViewProps) {
 
   // Operations log dialog state
   const [showOperationsLog, setShowOperationsLog] = useState(false);
+
+  // Workspace properties dialog state
+  const [showWorkspaceProperties, setShowWorkspaceProperties] = useState(false);
 
   // Drag and drop state
   const [draggedNoteId, setDraggedNoteId] = useState<string | null>(null);
@@ -145,6 +149,9 @@ function WorkspaceView({ workspaceInfo }: WorkspaceViewProps) {
       }
       if (event.payload === 'View > Operations Log clicked') {
         setShowOperationsLog(true);
+      }
+      if (event.payload === 'Edit > Workspace Properties clicked') {
+        setShowWorkspaceProperties(true);
       }
     });
 
@@ -754,6 +761,12 @@ function WorkspaceView({ workspaceInfo }: WorkspaceViewProps) {
       <OperationsLogDialog
         isOpen={showOperationsLog}
         onClose={() => setShowOperationsLog(false)}
+      />
+
+      {/* Workspace Properties Dialog */}
+      <WorkspacePropertiesDialog
+        isOpen={showWorkspaceProperties}
+        onClose={() => setShowWorkspaceProperties(false)}
       />
 
       {/* Hover Tooltip */}

--- a/krillnotes-desktop/src/types.ts
+++ b/krillnotes-desktop/src/types.ts
@@ -120,3 +120,16 @@ export interface WorkspaceEntry {
   path: string;
   isOpen: boolean;
 }
+
+export interface WorkspaceMetadata {
+  version: number;
+  authorName?: string;
+  authorOrg?: string;
+  homepageUrl?: string;
+  description?: string;
+  license?: string;
+  licenseUrl?: string;
+  language?: string;
+  /** Workspace-level taxonomy tags for gallery discovery (not per-note tags). */
+  tags: string[];
+}


### PR DESCRIPTION
Closes #37

## Summary

- **`WorkspaceMetadata` struct** replaces the old `WorkspaceJson` in `export.rs` — same `workspace.json` file, now carries author, org, homepage URL, description, license, license URL, language, and taxonomy tags. All fields are optional so old archives deserialise cleanly.
- **`get/set_workspace_metadata`** on `Workspace` — stored as a JSON blob under the `workspace_metadata` key in the existing `workspace_meta` table; no DB migration needed.
- **Export/import round-trip** — metadata is written to `workspace.json` on export and restored into the new workspace on import.
- **Two Tauri commands** — `get_workspace_metadata` / `set_workspace_metadata`.
- **Edit > Workspace Properties…** — new menu item, disabled until a workspace is open.
- **`WorkspacePropertiesDialog`** — form with all 8 fields. License uses a dropdown (CC BY 4.0, CC BY-SA 4.0, CC BY-NC 4.0, CC0 1.0, MIT, Apache 2.0, All Rights Reserved, Other…). Selecting a predefined license auto-fills the License URL field (read-only); choosing Other… unlocks both fields for custom input.

## Test plan

- [x] Open a workspace → Edit > Workspace Properties… opens dialog
- [x] Fill in fields, pick a predefined license — URL auto-fills and is read-only
- [x] Pick Other… — custom name + URL fields become editable
- [x] Save → reopen dialog → values persist
- [x] File > Export → File > Import → Edit > Workspace Properties… in new workspace shows imported values
- [x] Import an old `.krillnotes` archive (no metadata) → succeeds, properties dialog shows empty fields
- [x] `cargo test -p krillnotes-core` → 233 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)