### PR TITLE
perf: binary IPC for drag-and-drop attachments (#55)

### DIFF
--- a/krillnotes-desktop/src-tauri/src/lib.rs
+++ b/krillnotes-desktop/src-tauri/src/lib.rs
@@ -1421,14 +1421,44 @@ fn attach_file(
 
 /// Attaches a file to a note from raw bytes (used for drag-and-drop, where only
 /// file data — not a filesystem path — is available in the frontend).
+///
+/// Uses binary IPC: the caller passes a `Uint8Array` as the invoke body with
+/// `Content-Type: application/octet-stream`, avoiding the ~3× overhead of
+/// JSON number-array serialisation.  Metadata travels as HTTP headers:
+///   `x-note-id`  — note UUID (ASCII)
+///   `x-filename` — base64(UTF-8 bytes of filename) to survive ASCII-only headers
 #[tauri::command]
 fn attach_file_bytes(
+    request: tauri::ipc::Request<'_>,
     window: tauri::Window,
     state: State<'_, AppState>,
-    note_id: String,
-    filename: String,
-    data: Vec<u8>,
 ) -> std::result::Result<AttachmentMeta, String> {
+    // Extract raw binary body.
+    let tauri::ipc::InvokeBody::Raw(data) = request.body() else {
+        return Err("attach_file_bytes: expected raw binary body".to_string());
+    };
+    // note_id is a plain UUID — safe as ASCII header value.
+    let note_id = request
+        .headers()
+        .get("x-note-id")
+        .and_then(|v| v.to_str().ok())
+        .ok_or("attach_file_bytes: missing x-note-id header")?
+        .to_owned();
+    // filename is base64(UTF-8 bytes) so non-ASCII names survive the ASCII header constraint.
+    let filename_b64 = request
+        .headers()
+        .get("x-filename")
+        .and_then(|v| v.to_str().ok())
+        .ok_or("attach_file_bytes: missing x-filename header")?;
+    let filename_bytes = {
+        use base64::Engine;
+        base64::engine::general_purpose::STANDARD
+            .decode(filename_b64)
+            .map_err(|e| format!("attach_file_bytes: invalid filename encoding: {e}"))?
+    };
+    let filename = String::from_utf8(filename_bytes)
+        .map_err(|e| format!("attach_file_bytes: invalid UTF-8 in filename: {e}"))?;
+
     let label = window.label();
     let mut workspaces = state.workspaces.lock().expect("Mutex poisoned");
     let workspace = workspaces.get_mut(label).ok_or("No workspace open")?;
@@ -1436,7 +1466,7 @@ fn attach_file_bytes(
         .first()
         .map(|m| m.to_string());
     workspace
-        .attach_file(&note_id, &filename, mime_type.as_deref(), &data)
+        .attach_file(&note_id, &filename, mime_type.as_deref(), data)
         .map_err(|e| e.to_string())
 }
 

--- a/krillnotes-desktop/src/components/AttachmentsSection.tsx
+++ b/krillnotes-desktop/src/components/AttachmentsSection.tsx
@@ -62,8 +62,14 @@ export default function AttachmentsSection({ noteId }: AttachmentsSectionProps) 
     for (const file of files) {
       try {
         const buffer = await file.arrayBuffer();
-        const data = Array.from(new Uint8Array(buffer));
-        await invoke('attach_file_bytes', { noteId, filename: file.name, data });
+        // Encode filename as base64(UTF-8 bytes) — http headers are ASCII-only.
+        const nameBytes = new TextEncoder().encode(file.name);
+        let nameBinary = '';
+        for (const b of nameBytes) nameBinary += String.fromCharCode(b);
+        const filenameB64 = btoa(nameBinary);
+        await invoke('attach_file_bytes', new Uint8Array(buffer), {
+          headers: { 'x-note-id': noteId, 'x-filename': filenameB64 },
+        });
       } catch (err) {
         setError(`Failed to attach ${file.name}: ${err}`);
       }


### PR DESCRIPTION
## Summary

- Replaces `Array.from(new Uint8Array(buffer))` → JSON number array with direct `Uint8Array` binary IPC (Tauri v2 `InvokeBody::Raw`)
- `attach_file_bytes` now takes `request: tauri::ipc::Request<'_>` instead of `data: Vec<u8>`; extracts bytes from the raw body
- `note_id` travels as plain `x-note-id` header; `filename` travels as `x-filename: base64(UTF-8 bytes)` to survive the ASCII-only `HeaderValue` constraint
- A 10 MB file was ~30 MB of JSON over IPC; now it's exactly 10 MB

## Test plan

- [ ] Drag-and-drop a small file (image, PDF) — attaches correctly, thumbnail appears
- [ ] Drag-and-drop a file with a non-ASCII name (e.g. `日本語.pdf`) — name preserved correctly
- [ ] Drag-and-drop a large file (> 10 MB) — noticeably faster / no lag
- [ ] File-picker `+ Add` path unchanged (uses `attach_file`, not `attach_file_bytes`)
- [ ] Rust unit tests pass (`cargo test -p krillnotes-core`)
- [ ] TypeScript build clean (`tsc && vite build`)

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)