### PR TITLE
feat: HLC timestamps, signed operations, f64 positions (swarm milesto…

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -24,6 +24,7 @@ Krillnotes/
 │           ├── delete.rs          # Delete strategies (DeleteAll, PromoteChildren)
 │           ├── user_script.rs     # UserScript type + CRUD operations
 │           ├── export.rs          # Workspace export/import (zip archives)
+│           ├── hlc.rs             # HlcTimestamp, HlcClock — Hybrid Logical Clock
 │           ├── identity.rs        # Identity model (Ed25519 + Argon2id + AES-GCM + .swarmid)
 │           ├── undo.rs            # RetractInverse enum — undo/redo inverse operations
 │           ├── scripting/
@@ -84,7 +85,7 @@ Krillnotes/
 
 All data lives in a **workspace folder** on the user's disk. The folder contains:
 
-- `notes.db` — the SQLCipher-encrypted SQLite database (schema in [schema.sql](krillnotes-core/src/core/schema.sql))
+- `notes.db` — the SQLCipher-encrypted SQLite database (schema in [schema.sql](krillnotes-core/src/core/schema.sql)); contains 7 tables: `notes`, `note_tags`, `operations`, `workspace_meta`, `user_scripts`, `attachments`, `hlc_state`
 - `attachments/<uuid>` — per-file ChaCha20-Poly1305 encrypted blobs
 - `info.json` — unencrypted metadata sidecar (name, counts, workspace UUID) for the Workspace Manager
 
@@ -114,19 +115,30 @@ Operations are defined in [krillnotes-core/src/core/operation.rs](krillnotes-cor
 ```rust
 pub enum Operation {
     // Note operations
-    CreateNote { operation_id, timestamp, device_id, note_id, parent_id,
-                 position, node_type, title, fields, created_by },
-    UpdateField { operation_id, timestamp, device_id, note_id, field, value, modified_by },
-    DeleteNote  { operation_id, timestamp, device_id, note_id },
-    MoveNote    { operation_id, timestamp, device_id, note_id, new_parent_id, new_position },
+    CreateNote  { operation_id, timestamp: HlcTimestamp, device_id, note_id, parent_id,
+                  position: f64, node_type, title, fields, created_by, signature },
+    UpdateNote  { operation_id, timestamp: HlcTimestamp, device_id, note_id,
+                  title, modified_by, signature },
+    UpdateField { operation_id, timestamp: HlcTimestamp, device_id, note_id,
+                  field, value, modified_by, signature },
+    DeleteNote  { operation_id, timestamp: HlcTimestamp, device_id, note_id, signature },
+    MoveNote    { operation_id, timestamp: HlcTimestamp, device_id, note_id,
+                  new_parent_id, new_position: f64, signature },
+    SetTags     { operation_id, timestamp: HlcTimestamp, device_id, note_id,
+                  tags: Vec<String>, modified_by, signature },
 
     // User script operations
-    CreateUserScript { operation_id, timestamp, device_id, script_id, name, description },
-    UpdateUserScript { operation_id, timestamp, device_id, script_id, name, description },
-    DeleteUserScript { operation_id, timestamp, device_id, script_id },
+    CreateUserScript { operation_id, timestamp: HlcTimestamp, device_id, script_id,
+                       name, description, signature },
+    UpdateUserScript { operation_id, timestamp: HlcTimestamp, device_id, script_id,
+                       name, description, signature },
+    DeleteUserScript { operation_id, timestamp: HlcTimestamp, device_id,
+                       script_id, signature },
 
     // Undo/redo
-    RetractOperation { operation_id, timestamp, device_id, retracted_id },
+    RetractOperation { operation_id, timestamp: HlcTimestamp, device_id,
+                       retracted_ids: Vec<String>, inverse: RetractInverse,
+                       propagate: bool },
 }
 ```
 
@@ -134,10 +146,11 @@ pub enum Operation {
 
 Each operation carries:
 - A stable UUID (`operation_id`)
-- A wall-clock timestamp
+- An `HlcTimestamp` (Hybrid Logical Clock — `wall_ms`, `counter`, `node_id`) that is monotonic across devices and provides a total ordering for CRDT merge
 - The `device_id` of the originating machine
+- An Ed25519 `signature` over the canonical JSON payload (base64)
 
-This makes the log replayable and mergeable. The `synced` flag on each row (0 = local, 1 = acknowledged by a remote) is reserved for the future sync phase.
+This makes the log replayable, mergeable, and cryptographically attributable. The `synced` flag on each row (0 = local, 1 = acknowledged by a remote) is reserved for the future sync phase.
 
 **Purge strategies** ([operation_log.rs](krillnotes-core/src/core/operation_log.rs)):
 
@@ -341,11 +354,11 @@ Expansion and selection are *view state* — local to the device and not meaning
 
 ### 10. Tree Hierarchy
 
-Notes form an ordered tree via two columns: `parent_id` (nullable foreign key to `notes.id`) and `position` (zero-based integer sort order among siblings).
+Notes form an ordered tree via two columns: `parent_id` (nullable foreign key to `notes.id`) and `position` (a `REAL` / `f64` sort key among siblings).
 
 The database enforces referential integrity: deleting a note cascades to all its descendants.
 
-When a note is inserted as a sibling, all following siblings have their `position` incremented in the same transaction before the new row is inserted. This keeps positions gapless and consistent.
+`position` values are fractional (`f64`), which allows inserting a note between two existing siblings by picking a value between their positions — no sibling rows need to be updated. This is the standard mid-point strategy used by CRDTs for ordered sequences.
 
 ---
 
@@ -514,7 +527,8 @@ Tests live alongside the code they test in `#[cfg(test)]` modules at the bottom 
 | 9 — Encryption | Done | SQLCipher AES-256 for workspace DBs; optional AES-256 zip for exports |
 | 10 — Undo / redo | Done | `RetractOperation` log entries; undo groups; per-workspace history limit |
 | 11 — Identity model | Done | Ed25519 + Argon2id; workspace binding; `.swarmid` portable export |
-| 12 — Sync infrastructure | Planned | CRDT merge, conflict resolution, `synced` flag, swarm discovery |
+| 12 — HLC + signed operations | Done | `HlcTimestamp` per-operation; Ed25519 `signature` on every op; `hlc_state` table; fractional `f64` positions; `SetTags` + `UpdateNote` variants |
+| 13 — Sync infrastructure | Planned | CRDT merge, conflict resolution, `synced` flag, swarm discovery |
 
 ---
 
@@ -533,7 +547,8 @@ Tests live alongside the code they test in `#[cfg(test)]` modules at the bottom 
 | [krillnotes-core/src/core/storage.rs](krillnotes-core/src/core/storage.rs) | SQLCipher connection management, PRAGMA key, migrations, unencrypted-workspace detection |
 | [krillnotes-core/src/core/identity.rs](krillnotes-core/src/core/identity.rs) | Identity model — Ed25519 + Argon2id + AES-GCM; workspace bindings; `.swarmid` export/import |
 | [krillnotes-core/src/core/undo.rs](krillnotes-core/src/core/undo.rs) | `RetractInverse` enum — maps operations to their compensating inverses |
-| [krillnotes-core/src/core/schema.sql](krillnotes-core/src/core/schema.sql) | Database DDL (6 tables: notes, note_tags, operations, workspace_meta, user_scripts, attachments) |
+| [krillnotes-core/src/core/hlc.rs](krillnotes-core/src/core/hlc.rs) | `HlcTimestamp` (wall_ms, counter, node_id) and `HlcClock` — Hybrid Logical Clock for cross-device ordering |
+| [krillnotes-core/src/core/schema.sql](krillnotes-core/src/core/schema.sql) | Database DDL (7 tables: notes, note_tags, operations, workspace_meta, user_scripts, attachments, hlc_state) |
 | [krillnotes-desktop/src-tauri/build.rs](krillnotes-desktop/src-tauri/build.rs) | Compile-time locale embedding — generates `locales_generated.rs` from `src/i18n/locales/*.json` |
 | [krillnotes-desktop/src-tauri/src/lib.rs](krillnotes-desktop/src-tauri/src/lib.rs) | Tauri commands + AppState (identity manager, unlocked identities, menu item handles) |
 | [krillnotes-desktop/src-tauri/src/locales.rs](krillnotes-desktop/src-tauri/src/locales.rs) | `menu_strings(lang)` — locale lookup with English merge-over fallback |

--- a/krillnotes-core/Cargo.toml
+++ b/krillnotes-core/Cargo.toml
@@ -22,6 +22,7 @@ zip = { version = "8", default-features = false, features = ["deflate", "aes-cry
 pulldown-cmark = { version = "0.12", default-features = false, features = ["html"] }
 regex = "1"
 base64 = "0.22"
+blake3 = "1"
 
 # Encryption
 chacha20poly1305 = "0.10"

--- a/krillnotes-core/src/core/export.rs
+++ b/krillnotes-core/src/core/export.rs
@@ -499,7 +499,7 @@ pub fn import_workspace<R: Read + Seek>(
     drop(storage);
 
     // Rebuild the note_links index from the imported fields_json data.
-    let mut workspace = Workspace::open(db_path, workspace_password)
+    let mut workspace = Workspace::open(db_path, workspace_password, None)
         .map_err(|e| ExportError::Database(e.to_string()))?;
     workspace
         .rebuild_note_links_index()
@@ -595,7 +595,7 @@ mod tests {
     fn test_export_workspace_creates_valid_zip() {
         // Create a workspace with a note and a script
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         // Add a user script (unique name to avoid collision with starters)
         let script_source =
@@ -636,7 +636,7 @@ mod tests {
     fn test_peek_import_reads_metadata() {
         // Create a workspace with a script
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         let script_source =
             "// @name: Custom Widget\n// @description: Widget cards\nschema(\"Widget\", #{ fields: [] });";
@@ -662,7 +662,7 @@ mod tests {
     fn test_round_trip_export_import() {
         // Create a workspace with nested notes and a script
         let temp_src = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp_src.path(), "").unwrap();
+        let mut ws = Workspace::create(temp_src.path(), "", None).unwrap();
 
         let root = ws.list_all_notes().unwrap()[0].clone();
         ws.update_note_title(&root.id, "Root Note".to_string()).unwrap();
@@ -696,7 +696,7 @@ mod tests {
         assert!(result.script_count >= 2, "Should have starters + user script, got {}", result.script_count);
 
         // Open the imported workspace and verify contents
-        let imported_ws = Workspace::open(temp_dst.path(), "").unwrap();
+        let imported_ws = Workspace::open(temp_dst.path(), "", None).unwrap();
 
         let notes = imported_ws.list_all_notes().unwrap();
         assert_eq!(notes.len(), 3);
@@ -727,7 +727,7 @@ mod tests {
     #[test]
     fn test_export_includes_workspace_json() {
         let temp = NamedTempFile::new().unwrap();
-        let ws = Workspace::create(temp.path(), "").unwrap();
+        let ws = Workspace::create(temp.path(), "", None).unwrap();
 
         let mut buf = Vec::new();
         export_workspace(&ws, Cursor::new(&mut buf), None).unwrap();
@@ -741,7 +741,7 @@ mod tests {
     #[test]
     fn test_round_trip_preserves_tags() {
         let temp_src = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp_src.path(), "").unwrap();
+        let mut ws = Workspace::create(temp_src.path(), "", None).unwrap();
         let root = ws.list_all_notes().unwrap()[0].clone();
         ws.update_note_tags(&root.id, vec!["rust".into()]).unwrap();
 
@@ -751,7 +751,7 @@ mod tests {
         let temp_dst = NamedTempFile::new().unwrap();
         import_workspace(Cursor::new(&buf), temp_dst.path(), None, "").unwrap();
 
-        let imported = Workspace::open(temp_dst.path(), "").unwrap();
+        let imported = Workspace::open(temp_dst.path(), "", None).unwrap();
         let tags = imported.get_all_tags().unwrap();
         assert_eq!(tags, vec!["rust"]);
 
@@ -788,7 +788,7 @@ mod tests {
     #[test]
     fn test_export_with_password_creates_encrypted_zip() {
         let temp = NamedTempFile::new().unwrap();
-        let ws = Workspace::create(temp.path(), "").unwrap();
+        let ws = Workspace::create(temp.path(), "", None).unwrap();
 
         let mut buf = Vec::new();
         export_workspace(&ws, Cursor::new(&mut buf), Some("hunter2")).unwrap();
@@ -805,7 +805,7 @@ mod tests {
     #[test]
     fn test_export_without_password_creates_plain_zip() {
         let temp = NamedTempFile::new().unwrap();
-        let ws = Workspace::create(temp.path(), "").unwrap();
+        let ws = Workspace::create(temp.path(), "", None).unwrap();
 
         let mut buf = Vec::new();
         export_workspace(&ws, Cursor::new(&mut buf), None).unwrap();
@@ -820,7 +820,7 @@ mod tests {
     fn test_read_entry_wrong_password_returns_invalid_password() {
         // Export with a password
         let temp = NamedTempFile::new().unwrap();
-        let ws = Workspace::create(temp.path(), "").unwrap();
+        let ws = Workspace::create(temp.path(), "", None).unwrap();
         let mut buf = Vec::new();
         export_workspace(&ws, Cursor::new(&mut buf), Some("correct")).unwrap();
 
@@ -832,7 +832,7 @@ mod tests {
     #[test]
     fn test_peek_import_returns_encrypted_archive_error_when_no_password() {
         let temp = NamedTempFile::new().unwrap();
-        let ws = Workspace::create(temp.path(), "").unwrap();
+        let ws = Workspace::create(temp.path(), "", None).unwrap();
 
         let mut buf = Vec::new();
         export_workspace(&ws, Cursor::new(&mut buf), Some("s3cr3t")).unwrap();
@@ -844,7 +844,7 @@ mod tests {
     #[test]
     fn test_peek_import_with_correct_password_succeeds() {
         let temp = NamedTempFile::new().unwrap();
-        let ws = Workspace::create(temp.path(), "").unwrap();
+        let ws = Workspace::create(temp.path(), "", None).unwrap();
 
         let mut buf = Vec::new();
         export_workspace(&ws, Cursor::new(&mut buf), Some("s3cr3t")).unwrap();
@@ -857,7 +857,7 @@ mod tests {
     #[test]
     fn test_peek_import_with_wrong_password_returns_invalid_password() {
         let temp = NamedTempFile::new().unwrap();
-        let ws = Workspace::create(temp.path(), "").unwrap();
+        let ws = Workspace::create(temp.path(), "", None).unwrap();
 
         let mut buf = Vec::new();
         export_workspace(&ws, Cursor::new(&mut buf), Some("s3cr3t")).unwrap();
@@ -869,7 +869,7 @@ mod tests {
     #[test]
     fn test_encrypted_round_trip_import() {
         let temp_src = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp_src.path(), "").unwrap();
+        let mut ws = Workspace::create(temp_src.path(), "", None).unwrap();
         let root = ws.list_all_notes().unwrap()[0].clone();
         ws.update_note_title(&root.id, "Encrypted Root".to_string()).unwrap();
 
@@ -883,7 +883,7 @@ mod tests {
         assert_eq!(result.note_count, 1);
 
         // Verify imported note title
-        let imported_ws = Workspace::open(temp_dst.path(), "").unwrap();
+        let imported_ws = Workspace::open(temp_dst.path(), "", None).unwrap();
         let notes = imported_ws.list_all_notes().unwrap();
         assert!(notes.iter().any(|n| n.title == "Encrypted Root"));
     }
@@ -927,7 +927,7 @@ mod tests {
         let result = import_workspace(Cursor::new(&buf), temp_dst.path(), None, "").unwrap();
         assert_eq!(result.note_count, 1);
 
-        let imported_ws = Workspace::open(temp_dst.path(), "").unwrap();
+        let imported_ws = Workspace::open(temp_dst.path(), "", None).unwrap();
         let notes = imported_ws.list_all_notes().unwrap();
         assert_eq!(notes.len(), 1);
         assert!(notes[0].tags.is_empty(), "imported note from old archive should have no tags");
@@ -976,7 +976,7 @@ mod tests {
     #[test]
     fn test_workspace_metadata_roundtrip() {
         let temp_src = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp_src.path(), "").unwrap();
+        let mut ws = Workspace::create(temp_src.path(), "", None).unwrap();
 
         let meta = WorkspaceMetadata {
             version: 1,
@@ -997,7 +997,7 @@ mod tests {
         let temp_dst = NamedTempFile::new().unwrap();
         import_workspace(Cursor::new(&buf), temp_dst.path(), None, "").unwrap();
 
-        let imported = Workspace::open(temp_dst.path(), "").unwrap();
+        let imported = Workspace::open(temp_dst.path(), "", None).unwrap();
         let restored = imported.get_workspace_metadata().unwrap();
 
         assert_eq!(restored.author_name.as_deref(), Some("Alice"));
@@ -1014,7 +1014,7 @@ mod tests {
     fn test_export_includes_attachments() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("notes.db");
-        let mut ws = Workspace::create(&db_path, "").unwrap();
+        let mut ws = Workspace::create(&db_path, "", None).unwrap();
         let root_id = ws.list_all_notes().unwrap()[0].id.clone();
 
         ws.attach_file(&root_id, "hello.txt", Some("text/plain"), b"hello world").unwrap();
@@ -1036,7 +1036,7 @@ mod tests {
     fn test_import_restores_attachments() {
         let dir_src = tempfile::tempdir().unwrap();
         let db_src = dir_src.path().join("notes.db");
-        let mut ws = Workspace::create(&db_src, "pass").unwrap();
+        let mut ws = Workspace::create(&db_src, "pass", None).unwrap();
         let root_id = ws.list_all_notes().unwrap()[0].id.clone();
 
         ws.attach_file(&root_id, "data.txt", None, b"attachment content").unwrap();
@@ -1048,7 +1048,7 @@ mod tests {
         let db_dst = dir_dst.path().join("notes.db");
         import_workspace(Cursor::new(&buf), &db_dst, None, "newpass").unwrap();
 
-        let ws2 = Workspace::open(&db_dst, "newpass").unwrap();
+        let ws2 = Workspace::open(&db_dst, "newpass", None).unwrap();
         let notes = ws2.list_all_notes().unwrap();
         let root = notes.iter().find(|n| n.parent_id.is_none()).unwrap();
         let attachments = ws2.get_attachments(&root.id).unwrap();
@@ -1088,7 +1088,7 @@ mod tests {
         let temp_dst = NamedTempFile::new().unwrap();
         import_workspace(Cursor::new(&buf), temp_dst.path(), None, "").unwrap();
 
-        let imported = Workspace::open(temp_dst.path(), "").unwrap();
+        let imported = Workspace::open(temp_dst.path(), "", None).unwrap();
         let meta = imported.get_workspace_metadata().unwrap();
         assert!(meta.author_name.is_none());
         assert!(meta.tags.is_empty());

--- a/krillnotes-core/src/core/hlc.rs
+++ b/krillnotes-core/src/core/hlc.rs
@@ -1,0 +1,365 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2024-2026 TripleACS Pty Ltd t/a 2pi Software
+
+//! Hybrid Logical Clock (HLC) for distributed ordering of operations.
+//!
+//! An HLC combines a wall-clock timestamp with a logical counter to provide
+//! causally consistent ordering across nodes without tight clock synchronization.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use rusqlite::{Connection, Transaction};
+use serde::de::{self, SeqAccess, Visitor};
+use serde::ser::SerializeTuple;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use uuid::Uuid;
+
+/// A Hybrid Logical Clock timestamp.
+///
+/// Serializes as a compact 3-element JSON array `[wall_ms, counter, node_id]`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct HlcTimestamp {
+    pub wall_ms: u64,
+    pub counter: u32,
+    pub node_id: u32,
+}
+
+impl HlcTimestamp {
+    /// Construct an `HlcTimestamp` from a Unix timestamp in seconds.
+    ///
+    /// This is a compatibility helper for code that still generates
+    /// `chrono::Utc::now().timestamp()` (seconds). Counter and node_id
+    /// are zeroed; these timestamps should be replaced with proper HLC
+    /// values once the workspace acquires an `HlcClock`.
+    pub fn from_unix_secs(secs: i64) -> Self {
+        HlcTimestamp {
+            wall_ms: (secs.max(0) as u64).saturating_mul(1_000),
+            counter: 0,
+            node_id: 0,
+        }
+    }
+}
+
+impl Ord for HlcTimestamp {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.wall_ms
+            .cmp(&other.wall_ms)
+            .then(self.counter.cmp(&other.counter))
+            .then(self.node_id.cmp(&other.node_id))
+    }
+}
+
+impl PartialOrd for HlcTimestamp {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Serialize for HlcTimestamp {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut tup = serializer.serialize_tuple(3)?;
+        tup.serialize_element(&self.wall_ms)?;
+        tup.serialize_element(&self.counter)?;
+        tup.serialize_element(&self.node_id)?;
+        tup.end()
+    }
+}
+
+struct HlcTimestampVisitor;
+
+impl<'de> Visitor<'de> for HlcTimestampVisitor {
+    type Value = HlcTimestamp;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("a 3-element array [wall_ms, counter, node_id]")
+    }
+
+    fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<HlcTimestamp, A::Error> {
+        let wall_ms: u64 = seq
+            .next_element()?
+            .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+        let counter: u32 = seq
+            .next_element()?
+            .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+        let node_id: u32 = seq
+            .next_element()?
+            .ok_or_else(|| de::Error::invalid_length(2, &self))?;
+        Ok(HlcTimestamp {
+            wall_ms,
+            counter,
+            node_id,
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for HlcTimestamp {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<HlcTimestamp, D::Error> {
+        deserializer.deserialize_tuple(3, HlcTimestampVisitor)
+    }
+}
+
+/// Derive a stable 32-bit node ID from a device UUID.
+///
+/// Uses the first 4 bytes of a BLAKE3 hash of the device UUID bytes.
+pub fn node_id_from_device(device_id: &Uuid) -> u32 {
+    let hash = blake3::hash(device_id.as_bytes());
+    u32::from_le_bytes(hash.as_bytes()[..4].try_into().unwrap())
+}
+
+/// Returns the current wall-clock time as milliseconds since the Unix epoch.
+fn wall_clock_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
+}
+
+/// A Hybrid Logical Clock that can be advanced locally or by observing remote timestamps.
+pub struct HlcClock {
+    wall_ms: u64,
+    counter: u32,
+    node_id: u32,
+}
+
+impl HlcClock {
+    /// Create a new clock with the given node ID, starting at epoch zero.
+    pub fn new(node_id: u32) -> Self {
+        HlcClock {
+            wall_ms: 0,
+            counter: 0,
+            node_id,
+        }
+    }
+
+    /// Saturate a counter at `u32::MAX` rather than wrapping or panicking.
+    ///
+    /// In practice this requires billions of operations per millisecond, which is
+    /// impossible in any real deployment. If saturation does occur, timestamps at the
+    /// same `wall_ms` are still unique because they carry different `node_id` values.
+    fn saturating_increment(counter: u32) -> u32 {
+        counter.saturating_add(1)
+    }
+
+    /// Advance the clock and return the next timestamp.
+    ///
+    /// Guarantees monotonically increasing timestamps.
+    pub fn now(&mut self) -> HlcTimestamp {
+        let wall = wall_clock_ms();
+        let new_wall_ms = wall.max(self.wall_ms);
+        let counter = if new_wall_ms > self.wall_ms {
+            0
+        } else {
+            Self::saturating_increment(self.counter)
+        };
+        self.wall_ms = new_wall_ms;
+        self.counter = counter;
+        HlcTimestamp {
+            wall_ms: new_wall_ms,
+            counter,
+            node_id: self.node_id,
+        }
+    }
+
+    /// Update the clock by observing a remote timestamp.
+    ///
+    /// Does not return a timestamp — use `now()` afterwards if you need one.
+    pub fn observe(&mut self, remote: HlcTimestamp) {
+        let wall = wall_clock_ms();
+        let new_wall_ms = wall.max(self.wall_ms).max(remote.wall_ms);
+        let counter = if self.wall_ms == remote.wall_ms && remote.wall_ms == new_wall_ms {
+            // All three agree — take max counter and increment
+            Self::saturating_increment(self.counter.max(remote.counter))
+        } else if self.wall_ms == new_wall_ms {
+            // Local wall clock led
+            Self::saturating_increment(self.counter)
+        } else if remote.wall_ms == new_wall_ms {
+            // Remote wall clock led
+            Self::saturating_increment(remote.counter)
+        } else {
+            // Physical clock led (new_wall_ms == wall, which is ahead of both)
+            0
+        };
+        self.wall_ms = new_wall_ms;
+        self.counter = counter;
+    }
+
+    /// Load the HLC state from the `hlc_state` table.
+    ///
+    /// Returns `Err` if the table does not exist yet; returns `HlcClock::new(node_id)` if the
+    /// table exists but has no row. The `node_id` parameter is used only for the fallback —
+    /// when a row exists, the stored `node_id` takes priority.
+    pub fn load_from_db(conn: &Connection, node_id: u32) -> Result<Self, rusqlite::Error> {
+        let result = conn.query_row(
+            "SELECT wall_ms, counter, node_id FROM hlc_state WHERE id = 1",
+            [],
+            |row| {
+                // rusqlite does not implement FromSql/ToSql for u64/u32; store as i64 and cast.
+                // SQLite INTEGER is signed i64; wall_ms won't overflow i64 until year ~292M — safe cast.
+                let wall_ms = row.get::<_, i64>(0)? as u64;
+                let counter = row.get::<_, i64>(1)? as u32;
+                let node_id = row.get::<_, i64>(2)? as u32;
+                Ok(HlcClock {
+                    wall_ms,
+                    counter,
+                    node_id,
+                })
+            },
+        );
+        match result {
+            Ok(clock) => Ok(clock),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(HlcClock::new(node_id)),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Persist the current HLC state to the `hlc_state` table within a transaction.
+    pub fn save_to_db(&self, tx: &Transaction) -> Result<(), rusqlite::Error> {
+        // Cast to i64 — rusqlite has no ToSql impl for u64/u32.
+        // SQLite INTEGER is signed i64; wall_ms won't overflow i64 until year ~292M — safe cast.
+        tx.execute(
+            "INSERT OR REPLACE INTO hlc_state (id, wall_ms, counter, node_id) VALUES (1, ?, ?, ?)",
+            rusqlite::params![self.wall_ms as i64, self.counter as i64, self.node_id as i64],
+        )?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn now_is_monotonic() {
+        let mut clock = HlcClock::new(1);
+        let mut prev = clock.now();
+        for _ in 0..999 {
+            let next = clock.now();
+            assert!(
+                next >= prev,
+                "clock went backwards: {:?} < {:?}",
+                next,
+                prev
+            );
+            prev = next;
+        }
+    }
+
+    #[test]
+    fn observe_updates_clock_local_wins() {
+        let mut clock = HlcClock::new(1);
+        // Use a far-future wall_ms so the real system time does not overtake the seeded value.
+        // This ensures the "local led" branch is taken (self.wall_ms == new_wall_ms).
+        let future_ms = 2_000_000_000_000u64; // year 2033+
+        clock.wall_ms = future_ms;
+        clock.counter = 5;
+
+        let remote = HlcTimestamp {
+            wall_ms: future_ms - 1_000,
+            counter: 10,
+            node_id: 2,
+        };
+        clock.observe(remote);
+        // Local wall_ms dominates (it was already in the future relative to system time)
+        assert_eq!(clock.wall_ms, future_ms, "wall_ms should stay at future_ms");
+        // Local led: counter = self.counter + 1 = 6
+        assert_eq!(clock.counter, 6, "counter should be self.counter + 1");
+    }
+
+    #[test]
+    fn observe_updates_clock_remote_wins() {
+        let mut clock = HlcClock::new(1);
+        clock.wall_ms = 500;
+        clock.counter = 3;
+
+        let remote = HlcTimestamp {
+            wall_ms: 2_000_000_000_000, // far future
+            counter: 7,
+            node_id: 2,
+        };
+        clock.observe(remote);
+        assert_eq!(clock.wall_ms, 2_000_000_000_000);
+        // remote led, so counter = remote.counter + 1
+        assert_eq!(clock.counter, 8);
+    }
+
+    #[test]
+    fn observe_updates_clock_tie() {
+        let mut clock = HlcClock::new(1);
+        // Set wall_ms to the same value as the remote AND ensure system time does not exceed it.
+        // We use a large future value so the real clock won't catch up.
+        let future_ms = 2_000_000_000_000u64; // year 2033+
+        clock.wall_ms = future_ms;
+        clock.counter = 3;
+
+        let remote = HlcTimestamp {
+            wall_ms: future_ms,
+            counter: 5,
+            node_id: 2,
+        };
+        clock.observe(remote);
+        // Both local and remote share new_wall_ms → counter = max(3,5)+1 = 6
+        assert_eq!(clock.wall_ms, future_ms);
+        assert_eq!(clock.counter, 6);
+    }
+
+    #[test]
+    fn node_id_from_device_is_stable() {
+        let uuid1 = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let uuid2 = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+
+        let id1a = node_id_from_device(&uuid1);
+        let id1b = node_id_from_device(&uuid1);
+        let id2 = node_id_from_device(&uuid2);
+
+        assert_eq!(id1a, id1b, "same UUID must produce same node_id");
+        assert_ne!(id1a, id2, "different UUIDs should produce different node_ids");
+    }
+
+    #[test]
+    fn hlc_timestamp_serde_round_trip() {
+        let ts = HlcTimestamp {
+            wall_ms: 1_700_000_000_000,
+            counter: 42,
+            node_id: 99,
+        };
+
+        let json = serde_json::to_string(&ts).unwrap();
+        // Must be a 3-element array, not an object
+        assert_eq!(json, "[1700000000000,42,99]");
+
+        let decoded: HlcTimestamp = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, ts);
+    }
+
+    #[test]
+    fn hlc_timestamp_ordering() {
+        let a = HlcTimestamp {
+            wall_ms: 100,
+            counter: 0,
+            node_id: 1,
+        };
+        let b = HlcTimestamp {
+            wall_ms: 200,
+            counter: 0,
+            node_id: 1,
+        };
+        let c = HlcTimestamp {
+            wall_ms: 200,
+            counter: 1,
+            node_id: 1,
+        };
+        let d = HlcTimestamp {
+            wall_ms: 200,
+            counter: 1,
+            node_id: 2,
+        };
+
+        assert!(a < b, "earlier wall_ms must be less");
+        assert!(b < c, "same wall_ms, higher counter must be greater");
+        assert!(c < d, "same wall_ms+counter, higher node_id must be greater");
+        assert_eq!(a, a, "reflexive equality");
+    }
+}

--- a/krillnotes-core/src/core/identity.rs
+++ b/krillnotes-core/src/core/identity.rs
@@ -324,6 +324,22 @@ impl IdentityManager {
         Ok(settings.identities)
     }
 
+    /// Look up the display name for a given base64-encoded public key.
+    /// Reads each identity file until a match is found. Returns `None` if
+    /// no local identity has that public key.
+    pub fn lookup_display_name(&self, public_key: &str) -> Option<String> {
+        let settings = self.load_settings().ok()?;
+        for identity_ref in &settings.identities {
+            let file_path = self.identities_dir().join(format!("{}.json", identity_ref.uuid));
+            let Ok(data) = std::fs::read_to_string(&file_path) else { continue };
+            let Ok(identity_file) = serde_json::from_str::<IdentityFile>(&data) else { continue };
+            if identity_file.public_key == public_key {
+                return Some(identity_file.display_name);
+            }
+        }
+        None
+    }
+
     /// Delete an identity. Fails if any workspaces are still bound to it.
     pub fn delete_identity(&self, identity_uuid: &Uuid) -> Result<()> {
         let mut settings = self.load_settings()?;

--- a/krillnotes-core/src/core/mod.rs
+++ b/krillnotes-core/src/core/mod.rs
@@ -11,6 +11,7 @@
 
 pub mod attachment;
 pub mod delete;
+pub mod hlc;
 pub mod identity;
 pub mod export;
 pub mod device;

--- a/krillnotes-core/src/core/note.rs
+++ b/krillnotes-core/src/core/note.rs
@@ -8,7 +8,7 @@
 
 use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 /// A typed value stored in a note's schema-defined fields.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -47,8 +47,8 @@ pub struct Note {
     pub node_type: String,
     /// ID of the parent note, or `None` for root-level notes.
     pub parent_id: Option<String>,
-    /// Zero-based sort order among siblings that share the same `parent_id`.
-    pub position: i32,
+    /// Fractional sort order among siblings that share the same `parent_id`.
+    pub position: f64,
     /// Unix timestamp (seconds) when this note was created.
     pub created_at: i64,
     /// Unix timestamp (seconds) of the most recent modification.
@@ -58,7 +58,7 @@ pub struct Note {
     /// Device ID that last modified this note.
     pub modified_by: i64,
     /// Schema-defined field values keyed by field name.
-    pub fields: HashMap<String, FieldValue>,
+    pub fields: BTreeMap<String, FieldValue>,
     /// Whether this node is currently expanded in the tree UI.
     pub is_expanded: bool,
     /// Sorted, lowercase tags attached to this note.
@@ -78,12 +78,12 @@ mod tests {
             title: "Test Note".to_string(),
             node_type: "TextNote".to_string(),
             parent_id: None,
-            position: 0,
+            position: 0.0,
             created_at: 1234567890,
             modified_at: 1234567890,
             created_by: 0,
             modified_by: 0,
-            fields: HashMap::new(),
+            fields: BTreeMap::new(),
             is_expanded: true,
             tags: vec![],
         };

--- a/krillnotes-core/src/core/operation.rs
+++ b/krillnotes-core/src/core/operation.rs
@@ -6,15 +6,16 @@
 
 //! CRDT-style operation types for the Krillnotes operation log.
 
+use crate::core::hlc::HlcTimestamp;
 use crate::FieldValue;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 /// A single document mutation recorded in the workspace operation log.
 ///
 /// Operations capture the full intent of each change so they can be
 /// replayed, merged, or synced across devices in a future sync phase.
-/// Every variant carries a stable `operation_id`, a wall-clock `timestamp`,
+/// Every variant carries a stable `operation_id`, an HLC `timestamp`,
 /// and the `device_id` of the originating machine.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
@@ -23,31 +24,50 @@ pub enum Operation {
     CreateNote {
         /// Stable UUID for this operation.
         operation_id: String,
-        /// Unix timestamp (seconds) when the operation was created.
-        timestamp: i64,
+        /// HLC timestamp when the operation was created.
+        timestamp: HlcTimestamp,
         /// ID of the device that performed this operation.
         device_id: String,
         /// ID assigned to the new note.
         note_id: String,
         /// Parent note ID, or `None` for a root note.
         parent_id: Option<String>,
-        /// Zero-based position among siblings.
-        position: i32,
+        /// Fractional position among siblings.
+        position: f64,
         /// Schema type of the new note.
         node_type: String,
         /// Initial title of the new note.
         title: String,
         /// Initial field values of the new note.
-        fields: HashMap<String, FieldValue>,
-        /// Device ID logged as the creator.
-        created_by: i64,
+        fields: BTreeMap<String, FieldValue>,
+        /// Public key (base64) of the identity that created this note.
+        created_by: String,
+        /// Ed25519 signature over the canonical JSON payload (base64).
+        signature: String,
+    },
+    /// The title of an existing note was updated.
+    UpdateNote {
+        /// Stable UUID for this operation.
+        operation_id: String,
+        /// HLC timestamp when the operation was created.
+        timestamp: HlcTimestamp,
+        /// ID of the device that performed this operation.
+        device_id: String,
+        /// ID of the note whose title was updated.
+        note_id: String,
+        /// New title for the note.
+        title: String,
+        /// Public key (base64) of the identity that modified this note.
+        modified_by: String,
+        /// Ed25519 signature over the canonical JSON payload (base64).
+        signature: String,
     },
     /// A single schema field on an existing note was updated.
     UpdateField {
         /// Stable UUID for this operation.
         operation_id: String,
-        /// Unix timestamp (seconds) when the operation was created.
-        timestamp: i64,
+        /// HLC timestamp when the operation was created.
+        timestamp: HlcTimestamp,
         /// ID of the device that performed this operation.
         device_id: String,
         /// ID of the note whose field was updated.
@@ -56,41 +76,68 @@ pub enum Operation {
         field: String,
         /// New value for the field.
         value: FieldValue,
-        /// Device ID logged as the modifier.
-        modified_by: i64,
+        /// Public key (base64) of the identity that modified this note.
+        modified_by: String,
+        /// Ed25519 signature over the canonical JSON payload (base64).
+        signature: String,
     },
     /// A note (and all its descendants) was deleted.
     DeleteNote {
         /// Stable UUID for this operation.
         operation_id: String,
-        /// Unix timestamp (seconds) when the operation was created.
-        timestamp: i64,
+        /// HLC timestamp when the operation was created.
+        timestamp: HlcTimestamp,
         /// ID of the device that performed this operation.
         device_id: String,
         /// ID of the deleted note.
         note_id: String,
+        /// Public key (base64) of the identity that deleted this note.
+        deleted_by: String,
+        /// Ed25519 signature over the canonical JSON payload (base64).
+        signature: String,
     },
     /// A note was relocated to a new parent or position.
     MoveNote {
         /// Stable UUID for this operation.
         operation_id: String,
-        /// Unix timestamp (seconds) when the operation was created.
-        timestamp: i64,
+        /// HLC timestamp when the operation was created.
+        timestamp: HlcTimestamp,
         /// ID of the device that performed this operation.
         device_id: String,
         /// ID of the note that was moved.
         note_id: String,
         /// New parent note ID, or `None` to move to root level.
         new_parent_id: Option<String>,
-        /// New zero-based position among siblings.
-        new_position: i32,
+        /// New fractional position among siblings.
+        new_position: f64,
+        /// Public key (base64) of the identity that moved this note.
+        moved_by: String,
+        /// Ed25519 signature over the canonical JSON payload (base64).
+        signature: String,
+    },
+    /// The tags on an existing note were replaced.
+    SetTags {
+        /// Stable UUID for this operation.
+        operation_id: String,
+        /// HLC timestamp when the operation was created.
+        timestamp: HlcTimestamp,
+        /// ID of the device that performed this operation.
+        device_id: String,
+        /// ID of the note whose tags were updated.
+        note_id: String,
+        /// Full replacement tag list (normalised).
+        tags: Vec<String>,
+        /// Public key (base64) of the identity that modified this note.
+        modified_by: String,
+        /// Ed25519 signature over the canonical JSON payload (base64).
+        signature: String,
     },
     /// A new user script was created.
     CreateUserScript {
         /// Stable UUID for this operation.
         operation_id: String,
-        /// Unix timestamp (seconds) when the operation was created.
-        timestamp: i64,
+        /// HLC timestamp when the operation was created.
+        timestamp: HlcTimestamp,
         /// ID of the device that performed this operation.
         device_id: String,
         /// ID assigned to the new script.
@@ -105,13 +152,17 @@ pub enum Operation {
         load_order: i32,
         /// Whether the script is active.
         enabled: bool,
+        /// Public key (base64) of the identity that created this script.
+        created_by: String,
+        /// Ed25519 signature over the canonical JSON payload (base64).
+        signature: String,
     },
     /// An existing user script was modified (source, enabled state, or load order).
     UpdateUserScript {
         /// Stable UUID for this operation.
         operation_id: String,
-        /// Unix timestamp (seconds) when the operation was created.
-        timestamp: i64,
+        /// HLC timestamp when the operation was created.
+        timestamp: HlcTimestamp,
         /// ID of the device that performed this operation.
         device_id: String,
         /// ID of the script that was modified.
@@ -126,17 +177,25 @@ pub enum Operation {
         load_order: i32,
         /// Updated enabled state.
         enabled: bool,
+        /// Public key (base64) of the identity that modified this script.
+        modified_by: String,
+        /// Ed25519 signature over the canonical JSON payload (base64).
+        signature: String,
     },
     /// A user script was deleted.
     DeleteUserScript {
         /// Stable UUID for this operation.
         operation_id: String,
-        /// Unix timestamp (seconds) when the operation was created.
-        timestamp: i64,
+        /// HLC timestamp when the operation was created.
+        timestamp: HlcTimestamp,
         /// ID of the device that performed this operation.
         device_id: String,
         /// ID of the deleted script.
         script_id: String,
+        /// Public key (base64) of the identity that deleted this script.
+        deleted_by: String,
+        /// Ed25519 signature over the canonical JSON payload (base64).
+        signature: String,
     },
     /// Reverses one or more previously logged operations (undo).
     ///
@@ -145,8 +204,8 @@ pub enum Operation {
     RetractOperation {
         /// Stable UUID for this operation.
         operation_id: String,
-        /// Unix timestamp (seconds) when the operation was created.
-        timestamp: i64,
+        /// HLC timestamp when the operation was created.
+        timestamp: HlcTimestamp,
         /// ID of the device that performed this operation.
         device_id: String,
         /// Operation IDs that this retract reverses.
@@ -164,9 +223,11 @@ impl Operation {
     pub fn operation_id(&self) -> &str {
         match self {
             Self::CreateNote { operation_id, .. }
+            | Self::UpdateNote { operation_id, .. }
             | Self::UpdateField { operation_id, .. }
             | Self::DeleteNote { operation_id, .. }
             | Self::MoveNote { operation_id, .. }
+            | Self::SetTags { operation_id, .. }
             | Self::CreateUserScript { operation_id, .. }
             | Self::UpdateUserScript { operation_id, .. }
             | Self::DeleteUserScript { operation_id, .. }
@@ -174,14 +235,16 @@ impl Operation {
         }
     }
 
-    /// Returns the wall-clock Unix timestamp (seconds) when this operation was created.
+    /// Returns the HLC timestamp when this operation was created.
     #[must_use]
-    pub fn timestamp(&self) -> i64 {
+    pub fn timestamp(&self) -> HlcTimestamp {
         match self {
             Self::CreateNote { timestamp, .. }
+            | Self::UpdateNote { timestamp, .. }
             | Self::UpdateField { timestamp, .. }
             | Self::DeleteNote { timestamp, .. }
             | Self::MoveNote { timestamp, .. }
+            | Self::SetTags { timestamp, .. }
             | Self::CreateUserScript { timestamp, .. }
             | Self::UpdateUserScript { timestamp, .. }
             | Self::DeleteUserScript { timestamp, .. }
@@ -194,14 +257,133 @@ impl Operation {
     pub fn device_id(&self) -> &str {
         match self {
             Self::CreateNote { device_id, .. }
+            | Self::UpdateNote { device_id, .. }
             | Self::UpdateField { device_id, .. }
             | Self::DeleteNote { device_id, .. }
             | Self::MoveNote { device_id, .. }
+            | Self::SetTags { device_id, .. }
             | Self::CreateUserScript { device_id, .. }
             | Self::UpdateUserScript { device_id, .. }
             | Self::DeleteUserScript { device_id, .. }
             | Self::RetractOperation { device_id, .. } => device_id,
         }
+    }
+
+    /// Returns the base64-encoded public key of the author of this operation.
+    ///
+    /// Returns an empty string for `RetractOperation`, which is a local-only undo marker.
+    #[must_use]
+    pub fn author_key(&self) -> &str {
+        match self {
+            Self::CreateNote { created_by, .. } => created_by,
+            Self::UpdateNote { modified_by, .. } => modified_by,
+            Self::UpdateField { modified_by, .. } => modified_by,
+            Self::DeleteNote { deleted_by, .. } => deleted_by,
+            Self::MoveNote { moved_by, .. } => moved_by,
+            Self::SetTags { modified_by, .. } => modified_by,
+            Self::CreateUserScript { created_by, .. } => created_by,
+            Self::UpdateUserScript { modified_by, .. } => modified_by,
+            Self::DeleteUserScript { deleted_by, .. } => deleted_by,
+            Self::RetractOperation { .. } => "",
+        }
+    }
+
+    // ── Private helpers for sign/verify ────────────────────────────────────
+
+    fn set_author_key(&mut self, key: String) {
+        match self {
+            Self::CreateNote { created_by, .. } => *created_by = key,
+            Self::UpdateNote { modified_by, .. } => *modified_by = key,
+            Self::UpdateField { modified_by, .. } => *modified_by = key,
+            Self::DeleteNote { deleted_by, .. } => *deleted_by = key,
+            Self::MoveNote { moved_by, .. } => *moved_by = key,
+            Self::SetTags { modified_by, .. } => *modified_by = key,
+            Self::CreateUserScript { created_by, .. } => *created_by = key,
+            Self::UpdateUserScript { modified_by, .. } => *modified_by = key,
+            Self::DeleteUserScript { deleted_by, .. } => *deleted_by = key,
+            Self::RetractOperation { .. } => {}
+        }
+    }
+
+    fn set_signature(&mut self, sig: String) {
+        match self {
+            Self::CreateNote { signature, .. }
+            | Self::UpdateNote { signature, .. }
+            | Self::UpdateField { signature, .. }
+            | Self::DeleteNote { signature, .. }
+            | Self::MoveNote { signature, .. }
+            | Self::SetTags { signature, .. }
+            | Self::CreateUserScript { signature, .. }
+            | Self::UpdateUserScript { signature, .. }
+            | Self::DeleteUserScript { signature, .. } => *signature = sig,
+            Self::RetractOperation { .. } => {}
+        }
+    }
+
+    fn get_signature(&self) -> &str {
+        match self {
+            Self::CreateNote { signature, .. }
+            | Self::UpdateNote { signature, .. }
+            | Self::UpdateField { signature, .. }
+            | Self::DeleteNote { signature, .. }
+            | Self::MoveNote { signature, .. }
+            | Self::SetTags { signature, .. }
+            | Self::CreateUserScript { signature, .. }
+            | Self::UpdateUserScript { signature, .. }
+            | Self::DeleteUserScript { signature, .. } => signature,
+            Self::RetractOperation { .. } => "",
+        }
+    }
+
+    // ── Cryptographic signing ───────────────────────────────────────────────
+
+    /// Sign this operation in place. Sets the author key and signature.
+    ///
+    /// The canonical payload is the operation serialised to JSON with
+    /// `signature = ""` so that the signature field itself is not part of
+    /// what is signed.
+    pub fn sign(&mut self, key: &ed25519_dalek::SigningKey) {
+        use base64::{engine::general_purpose::STANDARD, Engine as _};
+        use ed25519_dalek::Signer;
+
+        // 1. Set the author key to the verifying key (base64).
+        let pubkey_bytes = key.verifying_key().to_bytes();
+        let pubkey_b64 = STANDARD.encode(pubkey_bytes);
+        self.set_author_key(pubkey_b64);
+
+        // 2. Set signature to "" for canonical payload.
+        self.set_signature(String::new());
+
+        // 3. Serialise and sign.
+        let payload = serde_json::to_string(self).expect("Operation must be serializable");
+        let sig = key.sign(payload.as_bytes());
+
+        // 4. Store the signature.
+        self.set_signature(STANDARD.encode(sig.to_bytes()));
+    }
+
+    /// Verify the Ed25519 signature on this operation against the provided public key.
+    ///
+    /// Returns `false` if the signature is missing, malformed, or invalid.
+    pub fn verify(&self, pubkey: &ed25519_dalek::VerifyingKey) -> bool {
+        use base64::{engine::general_purpose::STANDARD, Engine as _};
+        use ed25519_dalek::Verifier;
+
+        let sig_b64 = self.get_signature();
+        let Ok(sig_bytes) = STANDARD.decode(sig_b64) else {
+            return false;
+        };
+        let Ok(sig_bytes_arr) = <[u8; 64]>::try_from(sig_bytes) else {
+            return false;
+        };
+        let sig = ed25519_dalek::Signature::from_bytes(&sig_bytes_arr);
+
+        // Build canonical payload with signature = "".
+        let mut clone = self.clone();
+        clone.set_signature(String::new());
+        let payload = serde_json::to_string(&clone).expect("Operation must be serializable");
+
+        pubkey.verify(payload.as_bytes(), &sig).is_ok()
     }
 }
 
@@ -209,12 +391,24 @@ impl Operation {
 mod tests {
     use super::*;
 
+    fn dummy_timestamp() -> HlcTimestamp {
+        HlcTimestamp {
+            wall_ms: 1_000_000,
+            counter: 0,
+            node_id: 0,
+        }
+    }
+
     #[test]
     fn test_retract_operation_serialization() {
         use crate::RetractInverse;
         let op = Operation::RetractOperation {
             operation_id: "ret-1".into(),
-            timestamp: 9999,
+            timestamp: HlcTimestamp {
+                wall_ms: 9_999_000,
+                counter: 0,
+                node_id: 0,
+            },
             device_id: "dev-1".into(),
             retracted_ids: vec!["op-1".into(), "op-2".into()],
             inverse: RetractInverse::DeleteNote { note_id: "n-1".into() },
@@ -223,27 +417,146 @@ mod tests {
         let json = serde_json::to_string(&op).unwrap();
         let back: Operation = serde_json::from_str(&json).unwrap();
         assert_eq!(back.operation_id(), "ret-1");
-        assert_eq!(back.timestamp(), 9999);
+        assert_eq!(back.timestamp().wall_ms, 9_999_000);
     }
 
     #[test]
     fn test_operation_serialization() {
         let op = Operation::CreateNote {
             operation_id: "op-123".to_string(),
-            timestamp: 1234567890,
+            timestamp: dummy_timestamp(),
             device_id: "dev-1".to_string(),
             note_id: "note-1".to_string(),
             parent_id: None,
-            position: 0,
+            position: 0.0,
             node_type: "TextNote".to_string(),
             title: "Test".to_string(),
-            fields: HashMap::new(),
-            created_by: 0,
+            fields: BTreeMap::new(),
+            created_by: String::new(),
+            signature: String::new(),
         };
 
         let json = serde_json::to_string(&op).unwrap();
         let deserialized: Operation = serde_json::from_str(&json).unwrap();
 
         assert_eq!(op.operation_id(), deserialized.operation_id());
+    }
+
+    #[test]
+    fn test_sign_and_verify() {
+        use ed25519_dalek::SigningKey;
+        use rand::rngs::OsRng;
+
+        let signing_key = SigningKey::generate(&mut OsRng);
+        let verifying_key = signing_key.verifying_key();
+
+        let mut op = Operation::UpdateField {
+            operation_id: "op-sign-1".to_string(),
+            timestamp: dummy_timestamp(),
+            device_id: "dev-1".to_string(),
+            note_id: "note-1".to_string(),
+            field: "body".to_string(),
+            value: crate::FieldValue::Text("hello".to_string()),
+            modified_by: String::new(),
+            signature: String::new(),
+        };
+
+        op.sign(&signing_key);
+
+        // Signature and author key must be set after signing.
+        assert!(!op.get_signature().is_empty());
+        assert!(!op.author_key().is_empty());
+
+        // Verification must pass with the correct key.
+        assert!(op.verify(&verifying_key), "signature should verify");
+
+        // Tamper with the operation — verification must fail.
+        if let Operation::UpdateField { ref mut field, .. } = op {
+            *field = "tampered".to_string();
+        }
+        assert!(!op.verify(&verifying_key), "tampered operation should not verify");
+    }
+
+    #[test]
+    fn test_create_note_sign_and_verify_multi_field() {
+        use ed25519_dalek::SigningKey;
+        use rand::rngs::OsRng;
+
+        let signing_key = SigningKey::generate(&mut OsRng);
+        let verifying_key = signing_key.verifying_key();
+
+        // Build a CreateNote with multiple fields — order must be deterministic.
+        let mut fields = BTreeMap::new();
+        fields.insert("body".to_string(), crate::FieldValue::Text("hello world".to_string()));
+        fields.insert("rating".to_string(), crate::FieldValue::Text("5".to_string()));
+        fields.insert("author".to_string(), crate::FieldValue::Text("Alice".to_string()));
+
+        let mut op = Operation::CreateNote {
+            operation_id: "op-cn-sign-1".to_string(),
+            timestamp: dummy_timestamp(),
+            device_id: "dev-1".to_string(),
+            note_id: "note-multi-1".to_string(),
+            parent_id: None,
+            position: 0.0,
+            node_type: "TextNote".to_string(),
+            title: "Multi-field note".to_string(),
+            fields,
+            created_by: String::new(),
+            signature: String::new(),
+        };
+
+        op.sign(&signing_key);
+
+        assert!(!op.get_signature().is_empty());
+        assert!(!op.author_key().is_empty());
+
+        // Verification must succeed with the correct key.
+        assert!(op.verify(&verifying_key), "CreateNote multi-field signature should verify");
+
+        // Tamper with a field value — verification must fail.
+        if let Operation::CreateNote { ref mut title, .. } = op {
+            *title = "tampered".to_string();
+        }
+        assert!(!op.verify(&verifying_key), "tampered CreateNote should not verify");
+    }
+
+    #[test]
+    fn test_update_note_variant() {
+        let op = Operation::UpdateNote {
+            operation_id: "op-upd-1".to_string(),
+            timestamp: dummy_timestamp(),
+            device_id: "dev-2".to_string(),
+            note_id: "note-42".to_string(),
+            title: "New Title".to_string(),
+            modified_by: String::new(),
+            signature: String::new(),
+        };
+
+        let json = serde_json::to_string(&op).unwrap();
+        let back: Operation = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.operation_id(), "op-upd-1");
+        assert_eq!(back.author_key(), "");
+    }
+
+    #[test]
+    fn test_set_tags_variant() {
+        let op = Operation::SetTags {
+            operation_id: "op-tags-1".to_string(),
+            timestamp: dummy_timestamp(),
+            device_id: "dev-3".to_string(),
+            note_id: "note-7".to_string(),
+            tags: vec!["rust".to_string(), "crdt".to_string()],
+            modified_by: String::new(),
+            signature: String::new(),
+        };
+
+        let json = serde_json::to_string(&op).unwrap();
+        let back: Operation = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.operation_id(), "op-tags-1");
+        if let Operation::SetTags { tags, .. } = back {
+            assert_eq!(tags, vec!["rust", "crdt"]);
+        } else {
+            panic!("wrong variant after round-trip");
+        }
     }
 }

--- a/krillnotes-core/src/core/operation_log.rs
+++ b/krillnotes-core/src/core/operation_log.rs
@@ -30,10 +30,14 @@ pub enum PurgeStrategy {
 #[serde(rename_all = "camelCase")]
 pub struct OperationSummary {
     pub operation_id: String,
-    pub timestamp: i64,
+    /// HLC wall clock timestamp in Unix milliseconds.
+    pub timestamp_wall_ms: u64,
     pub device_id: String,
     pub operation_type: String,
     pub target_name: String,
+    /// First 8 characters of the base64 public key of the operation author,
+    /// or an empty string if the operation has no author (e.g. `RetractOperation`).
+    pub author_key: String,
 }
 
 /// Records document mutations to the `operations` table and purges stale entries.
@@ -55,13 +59,16 @@ impl OperationLog {
     /// [`crate::KrillnotesError::Json`] if `op` cannot be serialised.
     pub fn log(&self, tx: &Transaction, op: &Operation) -> Result<()> {
         let op_json = serde_json::to_string(op)?;
+        let ts = op.timestamp();
 
         tx.execute(
-            "INSERT INTO operations (operation_id, timestamp, device_id, operation_type, operation_data, synced)
-             VALUES (?, ?, ?, ?, ?, 0)",
+            "INSERT INTO operations (operation_id, timestamp_wall_ms, timestamp_counter, timestamp_node_id, device_id, operation_type, operation_data, synced)
+             VALUES (?, ?, ?, ?, ?, ?, ?, 0)",
             rusqlite::params![
                 op.operation_id(),
-                op.timestamp(),
+                ts.wall_ms as i64,
+                ts.counter as i64,
+                ts.node_id as i64,
                 op.device_id(),
                 self.operation_type_name(op),
                 op_json,
@@ -82,18 +89,21 @@ impl OperationLog {
         match self.strategy {
             PurgeStrategy::LocalOnly { keep_last } => {
                 tx.execute(
-                    "DELETE FROM operations WHERE id NOT IN (
-                        SELECT id FROM operations ORDER BY id DESC LIMIT ?
+                    "DELETE FROM operations WHERE operation_id NOT IN (
+                        SELECT operation_id FROM operations
+                        ORDER BY timestamp_wall_ms DESC, timestamp_counter DESC LIMIT ?
                     )",
                     [keep_last as i64],
                 )?;
             }
             PurgeStrategy::WithSync { retention_days } => {
-                let cutoff = chrono::Utc::now().timestamp()
-                    - (retention_days as i64 * SECONDS_PER_DAY);
+                // Convert retention cutoff from Unix seconds to wall_ms (milliseconds).
+                let cutoff_ms = (chrono::Utc::now().timestamp()
+                    - (retention_days as i64 * SECONDS_PER_DAY))
+                    * 1000;
                 tx.execute(
-                    "DELETE FROM operations WHERE synced = 1 AND timestamp < ?",
-                    [cutoff],
+                    "DELETE FROM operations WHERE synced = 1 AND timestamp_wall_ms < ?",
+                    [cutoff_ms],
                 )?;
             }
         }
@@ -116,7 +126,7 @@ impl OperationLog {
         until: Option<i64>,
     ) -> Result<Vec<OperationSummary>> {
         let mut sql = String::from(
-            "SELECT operation_id, timestamp, device_id, operation_type, operation_data FROM operations",
+            "SELECT operation_id, timestamp_wall_ms, device_id, operation_type, operation_data FROM operations",
         );
         let mut conditions: Vec<String> = Vec::new();
         let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
@@ -126,11 +136,13 @@ impl OperationLog {
             params.push(Box::new(t.to_string()));
         }
         if let Some(s) = since {
-            conditions.push("timestamp >= ?".to_string());
+            // `since` is in milliseconds (HLC wall_ms scale).
+            conditions.push("timestamp_wall_ms >= ?".to_string());
             params.push(Box::new(s));
         }
         if let Some(u) = until {
-            conditions.push("timestamp <= ?".to_string());
+            // `until` is in milliseconds (HLC wall_ms scale).
+            conditions.push("timestamp_wall_ms <= ?".to_string());
             params.push(Box::new(u));
         }
 
@@ -139,21 +151,26 @@ impl OperationLog {
             sql.push_str(&conditions.join(" AND "));
         }
 
-        sql.push_str(" ORDER BY timestamp DESC, id DESC");
+        sql.push_str(
+            " ORDER BY timestamp_wall_ms DESC, timestamp_counter DESC, timestamp_node_id DESC, operation_id DESC",
+        );
 
         let param_refs: Vec<&dyn rusqlite::types::ToSql> =
             params.iter().map(|p| p.as_ref()).collect();
 
         let mut stmt = conn.prepare(&sql)?;
         let rows = stmt.query_map(param_refs.as_slice(), |row| {
+            let wall_ms_raw: i64 = row.get(1)?;
             let operation_data: String = row.get(4)?;
             let target_name = Self::extract_target_name(&operation_data);
+            let author_key = Self::extract_author_key(&operation_data);
             Ok(OperationSummary {
                 operation_id: row.get(0)?,
-                timestamp: row.get(1)?,
+                timestamp_wall_ms: wall_ms_raw.max(0) as u64,
                 device_id: row.get(2)?,
                 operation_type: row.get(3)?,
                 target_name,
+                author_key,
             })
         })?;
 
@@ -177,9 +194,11 @@ impl OperationLog {
     fn operation_type_name(&self, op: &Operation) -> &str {
         match op {
             Operation::CreateNote { .. } => "CreateNote",
+            Operation::UpdateNote { .. } => "UpdateNote",
             Operation::UpdateField { .. } => "UpdateField",
             Operation::DeleteNote { .. } => "DeleteNote",
             Operation::MoveNote { .. } => "MoveNote",
+            Operation::SetTags { .. } => "SetTags",
             Operation::CreateUserScript { .. } => "CreateUserScript",
             Operation::UpdateUserScript { .. } => "UpdateUserScript",
             Operation::DeleteUserScript { .. } => "DeleteUserScript",
@@ -215,14 +234,41 @@ impl OperationLog {
 
         String::new()
     }
+
+    /// Extracts the first 8 characters of the base64 author public key from the
+    /// operation's JSON data.
+    ///
+    /// Checks fields in order: `created_by`, `modified_by`, `deleted_by`, `moved_by`.
+    /// Returns an empty string if none of these fields are present or non-empty
+    /// (e.g. `RetractOperation`).
+    fn extract_author_key(json: &str) -> String {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(json) else {
+            return String::new();
+        };
+
+        for field in &["created_by", "modified_by", "deleted_by", "moved_by"] {
+            if let Some(key) = value.get(field).and_then(|v| v.as_str()) {
+                if !key.is_empty() {
+                    return key.to_string();
+                }
+            }
+        }
+
+        String::new()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::hlc::HlcTimestamp;
     use crate::Storage;
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
     use tempfile::NamedTempFile;
+
+    fn ts(wall_ms: u64) -> HlcTimestamp {
+        HlcTimestamp { wall_ms, counter: 0, node_id: 0 }
+    }
 
     #[test]
     fn test_log_and_purge() {
@@ -232,18 +278,19 @@ mod tests {
 
         let tx = storage.connection_mut().transaction().unwrap();
 
-        for i in 0..10 {
+        for i in 0..10u64 {
             let op = Operation::CreateNote {
                 operation_id: format!("op-{}", i),
-                timestamp: 1000 + i,
+                timestamp: ts(1_000_000 + i),
                 device_id: "dev-1".to_string(),
                 note_id: format!("note-{}", i),
                 parent_id: None,
-                position: i as i32,
+                position: i as f64,
                 node_type: "TextNote".to_string(),
                 title: format!("Note {}", i),
-                fields: HashMap::new(),
-                created_by: 0,
+                fields: BTreeMap::new(),
+                created_by: String::new(),
+                signature: String::new(),
             };
             log.log(&tx, &op).unwrap();
         }
@@ -271,21 +318,22 @@ mod tests {
 
             let op1 = Operation::CreateNote {
                 operation_id: "op-1".to_string(),
-                timestamp: 1000,
+                timestamp: ts(1_000_000),
                 device_id: "dev-1".to_string(),
                 note_id: "note-1".to_string(),
                 parent_id: None,
-                position: 0,
+                position: 0.0,
                 node_type: "TextNote".to_string(),
                 title: "My Note".to_string(),
-                fields: HashMap::new(),
-                created_by: 0,
+                fields: BTreeMap::new(),
+                created_by: String::new(),
+                signature: String::new(),
             };
             log.log(&tx, &op1).unwrap();
 
             let op2 = Operation::CreateUserScript {
                 operation_id: "op-2".to_string(),
-                timestamp: 2000,
+                timestamp: ts(2_000_000),
                 device_id: "dev-1".to_string(),
                 script_id: "script-1".to_string(),
                 name: "My Script".to_string(),
@@ -293,6 +341,8 @@ mod tests {
                 source_code: "print(42);".to_string(),
                 load_order: 0,
                 enabled: true,
+                created_by: String::new(),
+                signature: String::new(),
             };
             log.log(&tx, &op2).unwrap();
 
@@ -316,9 +366,10 @@ mod tests {
         assert_eq!(notes_only.len(), 1);
         assert_eq!(notes_only[0].operation_id, "op-1");
 
-        // Filter by since.
+        // Filter by since (timestamp_wall_ms is in milliseconds).
+        // op1 stored at wall_ms=1_000_000, op2 at wall_ms=2_000_000.
         let recent = log
-            .list(storage.connection(), None, Some(1500), None)
+            .list(storage.connection(), None, Some(1_500_000), None)
             .unwrap();
         assert_eq!(recent.len(), 1);
         assert_eq!(recent[0].operation_id, "op-2");
@@ -332,18 +383,19 @@ mod tests {
 
         {
             let tx = storage.connection_mut().transaction().unwrap();
-            for i in 0..5 {
+            for i in 0..5u64 {
                 let op = Operation::CreateNote {
                     operation_id: format!("op-{}", i),
-                    timestamp: 1000 + i,
+                    timestamp: ts(1_000_000 + i),
                     device_id: "dev-1".to_string(),
                     note_id: format!("note-{}", i),
                     parent_id: None,
-                    position: i as i32,
+                    position: i as f64,
                     node_type: "TextNote".to_string(),
                     title: format!("Note {}", i),
-                    fields: HashMap::new(),
-                    created_by: 0,
+                    fields: BTreeMap::new(),
+                    created_by: String::new(),
+                    signature: String::new(),
                 };
                 log.log(&tx, &op).unwrap();
             }

--- a/krillnotes-core/src/core/schema.sql
+++ b/krillnotes-core/src/core/schema.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS notes (
     title TEXT NOT NULL,
     node_type TEXT NOT NULL,
     parent_id TEXT,
-    position INTEGER NOT NULL,
+    position REAL NOT NULL DEFAULT 0.0,
     created_at INTEGER NOT NULL,
     modified_at INTEGER NOT NULL,
     created_by INTEGER NOT NULL DEFAULT 0,
@@ -16,19 +16,28 @@ CREATE TABLE IF NOT EXISTS notes (
 
 CREATE INDEX IF NOT EXISTS idx_notes_parent ON notes(parent_id, position);
 
--- Operations log
+-- Operations log (HLC timestamps: wall clock ms + logical counter + node id)
 CREATE TABLE IF NOT EXISTS operations (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    operation_id TEXT UNIQUE NOT NULL,
-    timestamp INTEGER NOT NULL,
+    operation_id TEXT NOT NULL PRIMARY KEY,
+    timestamp_wall_ms INTEGER NOT NULL DEFAULT 0,
+    timestamp_counter INTEGER NOT NULL DEFAULT 0,
+    timestamp_node_id INTEGER NOT NULL DEFAULT 0,
     device_id TEXT NOT NULL,
     operation_type TEXT NOT NULL,
     operation_data TEXT NOT NULL,
-    synced INTEGER DEFAULT 0
+    synced INTEGER NOT NULL DEFAULT 0
 );
 
-CREATE INDEX IF NOT EXISTS idx_operations_timestamp ON operations(timestamp);
+CREATE INDEX IF NOT EXISTS idx_operations_timestamp_wall_ms ON operations(timestamp_wall_ms);
 CREATE INDEX IF NOT EXISTS idx_operations_synced ON operations(synced);
+
+-- HLC (Hybrid Logical Clock) state — single row, id=1 always
+CREATE TABLE IF NOT EXISTS hlc_state (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    wall_ms INTEGER NOT NULL,
+    counter INTEGER NOT NULL,
+    node_id INTEGER NOT NULL
+);
 
 -- Workspace metadata
 CREATE TABLE IF NOT EXISTS workspace_meta (

--- a/krillnotes-core/src/core/scripting/display_helpers.rs
+++ b/krillnotes-core/src/core/scripting/display_helpers.rs
@@ -15,7 +15,7 @@
 use pulldown_cmark::{html as md_html, Options, Parser};
 use rhai::{Array, Map};
 use std::sync::OnceLock;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use crate::{FieldValue, Note};
 use crate::core::attachment::AttachmentMeta;
 use super::schema::Schema;
@@ -40,7 +40,7 @@ fn html_escape(s: &str) -> String {
 ///                           then finds the attachment with that UUID
 pub fn resolve_attachment_source<'a>(
     source: &str,
-    fields: &HashMap<String, FieldValue>,
+    fields: &BTreeMap<String, FieldValue>,
     attachments: &'a [AttachmentMeta],
 ) -> Option<&'a AttachmentMeta> {
     if let Some(filename) = source.strip_prefix("attach:") {
@@ -72,7 +72,7 @@ static IMAGE_BLOCK_RE: OnceLock<regex::Regex> = OnceLock::new();
 
 pub fn preprocess_image_blocks(
     text: &str,
-    fields: &HashMap<String, FieldValue>,
+    fields: &BTreeMap<String, FieldValue>,
     attachments: &[AttachmentMeta],
 ) -> String {
     let re = IMAGE_BLOCK_RE.get_or_init(|| {
@@ -459,7 +459,7 @@ fn format_field_value_html(
     field_type: &str,
     max: i64,
     resolved_titles: &HashMap<String, String>,
-    image_context: Option<(&HashMap<String, FieldValue>, &[AttachmentMeta])>,
+    image_context: Option<(&BTreeMap<String, FieldValue>, &[AttachmentMeta])>,
 ) -> String {
     match (value, field_type) {
         (FieldValue::Text(s), "textarea") => {
@@ -659,7 +659,7 @@ pub fn render_default_view(
     attachments: &[AttachmentMeta],
 ) -> String {
     let mut sections: Vec<String> = Vec::new();
-    let image_ctx: Option<(&HashMap<String, FieldValue>, &[AttachmentMeta])> =
+    let image_ctx: Option<(&BTreeMap<String, FieldValue>, &[AttachmentMeta])> =
         Some((&note.fields, attachments));
 
     if let Some(schema) = schema {
@@ -831,14 +831,14 @@ mod tests {
     #[test]
     fn test_render_default_view_textarea_renders_markdown() {
         use crate::{FieldValue, FieldDefinition, Note, Schema};
-        use std::collections::HashMap;
+        use std::collections::{BTreeMap, HashMap};
 
-        let mut fields = HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("notes".into(), FieldValue::Text("**bold**".into()));
 
         let note = Note {
             id: "id1".into(), title: "Test".into(), node_type: "T".into(),
-            parent_id: None, position: 0, created_at: 0, modified_at: 0,
+            parent_id: None, position: 0.0, created_at: 0, modified_at: 0,
             created_by: 0, modified_by: 0, fields, is_expanded: false, tags: vec![],
         };
         let schema = Schema {
@@ -863,14 +863,14 @@ mod tests {
     #[test]
     fn test_render_default_view_text_field_html_escaped() {
         use crate::{FieldValue, FieldDefinition, Note, Schema};
-        use std::collections::HashMap;
+        use std::collections::{BTreeMap, HashMap};
 
-        let mut fields = HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("name".into(), FieldValue::Text("<script>alert(1)</script>".into()));
 
         let note = Note {
             id: "id2".into(), title: "T".into(), node_type: "T".into(),
-            parent_id: None, position: 0, created_at: 0, modified_at: 0,
+            parent_id: None, position: 0.0, created_at: 0, modified_at: 0,
             created_by: 0, modified_by: 0, fields, is_expanded: false, tags: vec![],
         };
         let schema = Schema {
@@ -895,14 +895,14 @@ mod tests {
     #[test]
     fn test_render_default_view_skips_can_view_false() {
         use crate::{FieldValue, FieldDefinition, Note, Schema};
-        use std::collections::HashMap;
+        use std::collections::{BTreeMap, HashMap};
 
-        let mut fields = HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("secret".into(), FieldValue::Text("hidden".into()));
 
         let note = Note {
             id: "id3".into(), title: "T".into(), node_type: "T".into(),
-            parent_id: None, position: 0, created_at: 0, modified_at: 0,
+            parent_id: None, position: 0.0, created_at: 0, modified_at: 0,
             created_by: 0, modified_by: 0, fields, is_expanded: false, tags: vec![],
         };
         let schema = Schema {
@@ -930,14 +930,14 @@ mod tests {
         // that contract so it is not accidentally "fixed" by escaping at this layer.
         use crate::{FieldValue, Note};
         use crate::{FieldDefinition, Schema};
-        use std::collections::HashMap;
+        use std::collections::{BTreeMap, HashMap};
 
-        let mut fields = HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("body".into(), FieldValue::Text("<em>italic</em> and **bold**".into()));
 
         let note = Note {
             id: "sec1".into(), title: "T".into(), node_type: "T".into(),
-            parent_id: None, position: 0, created_at: 0, modified_at: 0,
+            parent_id: None, position: 0.0, created_at: 0, modified_at: 0,
             created_by: 0, modified_by: 0, fields, is_expanded: false, tags: vec![],
         };
         let schema = Schema {
@@ -988,15 +988,15 @@ mod tests {
     #[test]
     fn test_render_default_view_legacy_fields_shown() {
         use crate::{FieldValue, FieldDefinition, Note, Schema};
-        use std::collections::HashMap;
+        use std::collections::{BTreeMap, HashMap};
 
-        let mut fields = HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("known".into(), FieldValue::Text("hello".into()));
         fields.insert("old_field".into(), FieldValue::Text("legacy value".into()));
 
         let note = Note {
             id: "id4".into(), title: "T".into(), node_type: "T".into(),
-            parent_id: None, position: 0, created_at: 0, modified_at: 0,
+            parent_id: None, position: 0.0, created_at: 0, modified_at: 0,
             created_by: 0, modified_by: 0, fields, is_expanded: false, tags: vec![],
         };
         let schema = Schema {
@@ -1070,7 +1070,7 @@ mod tests {
     #[test]
     fn test_resolve_by_filename() {
         let attachments = vec![make_meta("uuid-1", "photo.png")];
-        let fields = HashMap::new();
+        let fields = BTreeMap::new();
         let result = resolve_attachment_source("attach:photo.png", &fields, &attachments);
         assert_eq!(result.map(|a| a.id.as_str()), Some("uuid-1"));
     }
@@ -1078,7 +1078,7 @@ mod tests {
     #[test]
     fn test_resolve_by_field() {
         let attachments = vec![make_meta("uuid-2", "cover.jpg")];
-        let mut fields = HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("cover".to_string(), FieldValue::File(Some("uuid-2".to_string())));
         let result = resolve_attachment_source("field:cover", &fields, &attachments);
         assert_eq!(result.map(|a| a.id.as_str()), Some("uuid-2"));
@@ -1086,13 +1086,13 @@ mod tests {
 
     #[test]
     fn test_resolve_missing_returns_none() {
-        let fields = HashMap::new();
+        let fields = BTreeMap::new();
         assert!(resolve_attachment_source("attach:missing.png", &fields, &[]).is_none());
     }
 
     #[test]
     fn test_resolve_field_not_set_returns_none() {
-        let mut fields = HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("cover".to_string(), FieldValue::File(None));
         assert!(resolve_attachment_source("field:cover", &fields, &[]).is_none());
     }
@@ -1102,7 +1102,7 @@ mod tests {
     #[test]
     fn test_preprocess_basic_attach() {
         let attachments = vec![make_meta("uuid-1", "photo.png")];
-        let fields = HashMap::new();
+        let fields = BTreeMap::new();
         let result = preprocess_image_blocks(
             "Before {{image: attach:photo.png}} After",
             &fields,
@@ -1116,7 +1116,7 @@ mod tests {
     #[test]
     fn test_preprocess_with_width_and_alt() {
         let attachments = vec![make_meta("uuid-2", "cover.jpg")];
-        let fields = HashMap::new();
+        let fields = BTreeMap::new();
         let result = preprocess_image_blocks(
             "{{image: attach:cover.jpg, width: 300, alt: My cover}}",
             &fields,
@@ -1129,14 +1129,14 @@ mod tests {
 
     #[test]
     fn test_preprocess_unresolvable_shows_error() {
-        let fields = HashMap::new();
+        let fields = BTreeMap::new();
         let result = preprocess_image_blocks("{{image: attach:missing.png}}", &fields, &[]);
         assert!(result.contains("kn-image-error"), "got: {result}");
     }
 
     #[test]
     fn test_preprocess_field_source() {
-        let mut fields = HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("cover".to_string(), FieldValue::File(Some("uuid-3".to_string())));
         let attachments = vec![make_meta("uuid-3", "cover.jpg")];
         let result = preprocess_image_blocks("{{image: field:cover, width: 200}}", &fields, &attachments);
@@ -1324,16 +1324,16 @@ mod tests {
     #[test]
     fn test_render_default_view_textarea_bare_url_becomes_sentinel() {
         use crate::{FieldValue, FieldDefinition, Note, Schema};
-        use std::collections::HashMap;
+        use std::collections::{BTreeMap, HashMap};
 
-        let mut fields = HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert(
             "body".into(),
             FieldValue::Text("Watch this:\n\nhttps://www.youtube.com/watch?v=dQw4w9WgXcQ\n\nDone.".into()),
         );
         let note = Note {
             id: "id-embed".into(), title: "T".into(), node_type: "T".into(),
-            parent_id: None, position: 0, created_at: 0, modified_at: 0,
+            parent_id: None, position: 0.0, created_at: 0, modified_at: 0,
             created_by: 0, modified_by: 0, fields, is_expanded: false, tags: vec![],
         };
         let schema = Schema {

--- a/krillnotes-core/src/core/scripting/hooks.rs
+++ b/krillnotes-core/src/core/scripting/hooks.rs
@@ -11,7 +11,7 @@
 //! `schema()` Rhai host function.
 
 use rhai::{FnPtr, AST};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Mutex};
 
 /// A user-registered tree context-menu action.
@@ -39,7 +39,7 @@ pub struct ActionCreate {
     pub parent_id: String,
     pub node_type: String,
     pub title:     String,
-    pub fields:    std::collections::HashMap<String, crate::core::note::FieldValue>,
+    pub fields:    BTreeMap<String, crate::core::note::FieldValue>,
 }
 
 /// Spec for a note to be updated by a tree action.
@@ -47,7 +47,7 @@ pub struct ActionCreate {
 pub struct ActionUpdate {
     pub note_id: String,
     pub title:   String,
-    pub fields:  std::collections::HashMap<String, crate::core::note::FieldValue>,
+    pub fields:  BTreeMap<String, crate::core::note::FieldValue>,
 }
 
 /// Shared mutable context active during a tree action closure.

--- a/krillnotes-core/src/core/scripting/mod.rs
+++ b/krillnotes-core/src/core/scripting/mod.rs
@@ -25,7 +25,7 @@ use schema::HookEntry;
 use chrono::Local;
 use include_dir::{include_dir, Dir};
 use rhai::{Dynamic, Engine, EvalAltResult, FnPtr, Map, AST};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Mutex};
 
 /// Per-run context injected before executing a Rhai script so that
@@ -463,7 +463,7 @@ impl ScriptRegistry {
                         rhai::Position::NONE,
                     ))
                 })?;
-                let mut fields = std::collections::HashMap::new();
+                let mut fields = BTreeMap::new();
                 for field_def in &schema.fields {
                     let dyn_val = fields_dyn
                         .get(field_def.name.as_str())
@@ -650,8 +650,8 @@ impl ScriptRegistry {
         note_id: &str,
         node_type: &str,
         title: &str,
-        fields: &HashMap<String, FieldValue>,
-    ) -> Result<Option<(String, HashMap<String, FieldValue>)>> {
+        fields: &BTreeMap<String, FieldValue>,
+    ) -> Result<Option<(String, BTreeMap<String, FieldValue>)>> {
         let schema = self.schema_registry.get(schema_name)?;
         self.schema_registry
             .run_on_save_hook(&self.engine, &schema, note_id, node_type, title, fields)
@@ -672,11 +672,11 @@ impl ScriptRegistry {
         parent_id: &str,
         parent_type: &str,
         parent_title: &str,
-        parent_fields: &HashMap<String, FieldValue>,
+        parent_fields: &BTreeMap<String, FieldValue>,
         child_id: &str,
         child_type: &str,
         child_title: &str,
-        child_fields: &HashMap<String, FieldValue>,
+        child_fields: &BTreeMap<String, FieldValue>,
     ) -> Result<Option<AddChildResult>> {
         let parent_schema = self.schema_registry.get(parent_schema_name)?;
         let child_schema  = self.schema_registry.get(child_type)?;
@@ -908,7 +908,7 @@ mod tests {
             });
         "#, "test").unwrap();
 
-        let mut fields = std::collections::HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("first".to_string(), FieldValue::Text("John".to_string()));
         fields.insert("last".to_string(), FieldValue::Text("Doe".to_string()));
 
@@ -936,9 +936,9 @@ mod tests {
         use crate::Note;
         let note = Note {
             id: "n1".to_string(), node_type: "Folder".to_string(),
-            title: "F".to_string(), parent_id: None, position: 0,
+            title: "F".to_string(), parent_id: None, position: 0.0,
             created_at: 0, modified_at: 0, created_by: 0, modified_by: 0,
-            fields: std::collections::HashMap::new(), is_expanded: false, tags: vec![],
+            fields: std::collections::BTreeMap::new(), is_expanded: false, tags: vec![],
         };
         let ctx = QueryContext {
             notes_by_id: std::collections::HashMap::new(),
@@ -1219,7 +1219,7 @@ mod tests {
             "test")
             .unwrap();
 
-        let mut fields = HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("first".to_string(), FieldValue::Text("John".to_string()));
         fields.insert("last".to_string(), FieldValue::Text("Doe".to_string()));
 
@@ -1237,7 +1237,7 @@ mod tests {
     fn test_run_on_save_hook_no_hook_returns_none() {
         let mut registry = ScriptRegistry::new().unwrap();
         load_text_note(&mut registry);
-        let fields = HashMap::new();
+        let fields = BTreeMap::new();
         let result = registry
             .run_on_save_hook("TextNote", "id-1", "TextNote", "title", &fields)
             .unwrap();
@@ -1253,7 +1253,7 @@ mod tests {
         )), "Contact").unwrap();
         assert!(registry.has_hook("Contact"), "Contact schema should have an on_save hook");
 
-        let mut fields = HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("first_name".to_string(), FieldValue::Text("Jane".to_string()));
         fields.insert("middle_name".to_string(), FieldValue::Text("".to_string()));
         fields.insert("last_name".to_string(), FieldValue::Text("Smith".to_string()));
@@ -1440,7 +1440,7 @@ mod tests {
             .unwrap();
 
         // Do NOT include "flag" in the submitted fields — it must default to false.
-        let fields = HashMap::new();
+        let fields = BTreeMap::new();
 
         let result = registry
             .run_on_save_hook("FlagNote", "id-1", "FlagNote", "title", &fields)
@@ -1665,7 +1665,7 @@ mod tests {
             });
         "#, "test").unwrap();
 
-        let mut fields = HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("status".to_string(), FieldValue::Text("A".to_string()));
 
         let result = registry
@@ -1688,7 +1688,7 @@ mod tests {
             });
         "#, "test").unwrap();
 
-        let mut fields = HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("stars".to_string(), FieldValue::Number(0.0));
 
         let result = registry
@@ -1711,7 +1711,7 @@ mod tests {
             });
         "#, "test").unwrap();
 
-        let fields = HashMap::new(); // no status field
+        let fields = BTreeMap::new(); // no status field
         let result = registry
             .run_on_save_hook("S2", "id1", "S2", "title", &fields)
             .unwrap()
@@ -1732,7 +1732,7 @@ mod tests {
             });
         "#, "test").unwrap();
 
-        let fields = HashMap::new(); // no stars field
+        let fields = BTreeMap::new(); // no stars field
         let result = registry
             .run_on_save_hook("R2", "id1", "R2", "title", &fields)
             .unwrap()
@@ -1790,7 +1790,7 @@ mod tests {
             "/../templates/book_collection.rhai"
         )), "book_collection").expect("book_collection.rhai should load");
 
-        let mut fields = std::collections::HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("book_title".to_string(), crate::FieldValue::Text("Dune".to_string()));
         fields.insert("author".to_string(), crate::FieldValue::Text("Herbert".to_string()));
         fields.insert("genre".to_string(), crate::FieldValue::Text(String::new()));
@@ -1813,7 +1813,7 @@ mod tests {
     #[test]
     fn test_script_registry_render_default_view_textarea_markdown() {
         use crate::{FieldValue, Note};
-        use std::collections::HashMap;
+        use std::collections::{BTreeMap, HashMap};
 
         let mut registry = ScriptRegistry::new().unwrap();
         registry.load_script(r#"
@@ -1824,11 +1824,11 @@ mod tests {
             });
         "#, "test").unwrap();
 
-        let mut fields = HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("body".into(), FieldValue::Text("**important**".into()));
         let note = Note {
             id: "n1".into(), title: "Test".into(), node_type: "Memo".into(),
-            parent_id: None, position: 0, created_at: 0, modified_at: 0,
+            parent_id: None, position: 0.0, created_at: 0, modified_at: 0,
             created_by: 0, modified_by: 0, fields, is_expanded: false, tags: vec![],
         };
 
@@ -1869,12 +1869,12 @@ mod tests {
             node_type: "LinkTest".to_string(),
             title: "Test".to_string(),
             parent_id: None,
-            position: 0,
+            position: 0.0,
             created_at: 0,
             modified_at: 0,
             created_by: 0,
             modified_by: 0,
-            fields: HashMap::new(),
+            fields: BTreeMap::new(),
             is_expanded: false, tags: vec![],
         };
 
@@ -1912,7 +1912,7 @@ mod tests {
             "My Exploding Script",
         ).unwrap();
 
-        let fields = HashMap::new();
+        let fields = BTreeMap::new();
         let err = registry
             .run_on_save_hook("Boom", "id-1", "Boom", "title", &fields)
             .unwrap_err();
@@ -1947,10 +1947,10 @@ mod tests {
             });
         "#, "test").unwrap();
 
-        let mut parent_fields = std::collections::HashMap::new();
+        let mut parent_fields = BTreeMap::new();
         parent_fields.insert("count".to_string(), FieldValue::Number(0.0));
 
-        let mut child_fields = std::collections::HashMap::new();
+        let mut child_fields = BTreeMap::new();
         child_fields.insert("name".to_string(), FieldValue::Text("".to_string()));
 
         let result = registry
@@ -1982,8 +1982,8 @@ mod tests {
         let result = registry
             .run_on_add_child_hook(
                 "Plain",
-                "p-id", "Plain", "Title", &std::collections::HashMap::new(),
-                "c-id", "Plain", "Child", &std::collections::HashMap::new(),
+                "p-id", "Plain", "Title", &std::collections::BTreeMap::new(),
+                "c-id", "Plain", "Child", &std::collections::BTreeMap::new(),
             )
             .unwrap();
 
@@ -2008,8 +2008,8 @@ mod tests {
         let result = registry
             .run_on_add_child_hook(
                 "Folder",
-                "p-id", "Folder", "Title", &std::collections::HashMap::new(),
-                "c-id", "Item",   "Child", &std::collections::HashMap::new(),
+                "p-id", "Folder", "Title", &std::collections::BTreeMap::new(),
+                "c-id", "Item",   "Child", &std::collections::BTreeMap::new(),
             )
             .unwrap();
 
@@ -2037,14 +2037,14 @@ mod tests {
             });
         "#, "test").unwrap();
 
-        let mut parent_fields = std::collections::HashMap::new();
+        let mut parent_fields = BTreeMap::new();
         parent_fields.insert("count".to_string(), FieldValue::Number(0.0));
 
         let result = registry
             .run_on_add_child_hook(
                 "Folder",
                 "p-id", "Folder", "Folder", &parent_fields,
-                "c-id", "Item",   "Untitled", &std::collections::HashMap::new(),
+                "c-id", "Item",   "Untitled", &std::collections::BTreeMap::new(),
             )
             .unwrap();
 
@@ -2073,8 +2073,8 @@ mod tests {
         let result = registry
             .run_on_add_child_hook(
                 "Folder",
-                "p-id", "Folder", "Folder", &std::collections::HashMap::new(),
-                "c-id", "Item",   "Untitled", &std::collections::HashMap::new(),
+                "p-id", "Folder", "Folder", &std::collections::BTreeMap::new(),
+                "c-id", "Item",   "Untitled", &std::collections::BTreeMap::new(),
             )
             .unwrap();
 
@@ -2102,8 +2102,8 @@ mod tests {
         let err = registry
             .run_on_add_child_hook(
                 "Folder",
-                "p-id", "Folder", "Title", &std::collections::HashMap::new(),
-                "c-id", "Item",   "Child", &std::collections::HashMap::new(),
+                "p-id", "Folder", "Title", &std::collections::BTreeMap::new(),
+                "c-id", "Item",   "Child", &std::collections::BTreeMap::new(),
             )
             .unwrap_err();
 
@@ -2131,9 +2131,9 @@ mod tests {
         use crate::Note;
         let note = Note {
             id: "n1".to_string(), node_type: "BoomView".to_string(),
-            title: "T".to_string(), parent_id: None, position: 0,
+            title: "T".to_string(), parent_id: None, position: 0.0,
             created_at: 0, modified_at: 0, created_by: 0, modified_by: 0,
-            fields: HashMap::new(), is_expanded: false, tags: vec![],
+            fields: BTreeMap::new(), is_expanded: false, tags: vec![],
         };
         let ctx = QueryContext {
             notes_by_id: HashMap::new(),
@@ -2189,7 +2189,7 @@ mod tests {
         let note = crate::Note {
             id: "n1".into(), title: "Hello".into(),
             node_type: "TextNote".into(), parent_id: None,
-            fields: std::collections::HashMap::new(), position: 0,
+            fields: std::collections::BTreeMap::new(), position: 0.0,
             created_at: 0, modified_at: 0, created_by: 0, modified_by: 0,
             is_expanded: false, tags: vec![],
         };
@@ -2215,7 +2215,7 @@ mod tests {
         let note = crate::Note {
             id: "p1".into(), title: "Parent".into(),
             node_type: "TextNote".into(), parent_id: None,
-            fields: std::collections::HashMap::new(), position: 0,
+            fields: std::collections::BTreeMap::new(), position: 0.0,
             created_at: 0, modified_at: 0, created_by: 0, modified_by: 0,
             is_expanded: false, tags: vec![],
         };
@@ -2237,7 +2237,7 @@ mod tests {
         let note = crate::Note {
             id: "n1".into(), title: "T".into(),
             node_type: "TextNote".into(), parent_id: None,
-            fields: std::collections::HashMap::new(), position: 0,
+            fields: std::collections::BTreeMap::new(), position: 0.0,
             created_at: 0, modified_at: 0, created_by: 0, modified_by: 0,
             is_expanded: false, tags: vec![],
         };
@@ -2263,7 +2263,7 @@ mod tests {
         let note = crate::Note {
             id: "n1".into(), title: "T".into(),
             node_type: "TextNote".into(), parent_id: None,
-            fields: std::collections::HashMap::new(), position: 0,
+            fields: std::collections::BTreeMap::new(), position: 0.0,
             created_at: 0, modified_at: 0, created_by: 0, modified_by: 0,
             is_expanded: false, tags: vec![],
         };
@@ -2285,7 +2285,7 @@ mod tests {
         crate::Note {
             id: id.into(), title: "Test".into(),
             node_type: node_type.into(), parent_id: None,
-            fields: Default::default(), position: 0,
+            fields: Default::default(), position: 0.0,
             created_at: 0, modified_at: 0, created_by: 0, modified_by: 0,
             is_expanded: false, tags: vec![],
         }
@@ -2432,9 +2432,9 @@ mod tests {
 
         let note = Note {
             id: "n1".to_string(), node_type: "Tagged".to_string(),
-            title: "T".to_string(), parent_id: None, position: 0,
+            title: "T".to_string(), parent_id: None, position: 0.0,
             created_at: 0, modified_at: 0, created_by: 0, modified_by: 0,
-            fields: std::collections::HashMap::new(), is_expanded: false,
+            fields: std::collections::BTreeMap::new(), is_expanded: false,
             tags: vec!["rust".to_string(), "notes".to_string()],
         };
         let ctx = QueryContext {
@@ -2464,7 +2464,7 @@ mod tests {
         "#, "test").unwrap();
 
         let result = registry
-            .run_on_save_hook("DateTest", "id1", "DateTest", "", &HashMap::new())
+            .run_on_save_hook("DateTest", "id1", "DateTest", "", &BTreeMap::new())
             .unwrap()
             .unwrap();
         let (title, _) = result;
@@ -2501,7 +2501,7 @@ mod tests {
             });
         "#, "test").unwrap();
 
-        let mut fields = std::collections::HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("body".to_string(),
             FieldValue::Text("Emergence is when simple rules produce complex behaviour".to_string()));
 
@@ -2545,7 +2545,7 @@ mod tests {
         "#, "test").unwrap();
 
         let (title, _) = registry
-            .run_on_save_hook("ZettelEmpty", "id2", "ZettelEmpty", "", &std::collections::HashMap::new())
+            .run_on_save_hook("ZettelEmpty", "id2", "ZettelEmpty", "", &std::collections::BTreeMap::new())
             .unwrap().unwrap();
         assert!(title.contains("Untitled"), "expected Untitled fallback: {title}");
         // Must still have the date prefix
@@ -2623,9 +2623,9 @@ mod tests {
         "#, "HoverRun").unwrap();
         let note = crate::Note {
             id: "id1".into(), title: "Test Note".into(), node_type: "HoverRun".into(),
-            parent_id: None, position: 0, created_at: 0, modified_at: 0,
+            parent_id: None, position: 0.0, created_at: 0, modified_at: 0,
             created_by: 0, modified_by: 0,
-            fields: std::collections::HashMap::new(), is_expanded: false, tags: vec![],
+            fields: std::collections::BTreeMap::new(), is_expanded: false, tags: vec![],
         };
         let ctx = QueryContext {
             notes_by_id: Default::default(), children_by_id: Default::default(),
@@ -2709,12 +2709,12 @@ mod tests {
             });
         "#, "test_script").unwrap();
 
-        let mut fields = std::collections::HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("photo".to_string(), FieldValue::File(Some("abc-uuid-123".to_string())));
         let note = Note {
             id: "n1".to_string(), node_type: "PhotoNote".to_string(),
             title: "T".to_string(), parent_id: None, fields, tags: vec![],
-            created_at: 0, modified_at: 0, position: 0,
+            created_at: 0, modified_at: 0, position: 0.0,
             created_by: 0, modified_by: 0, is_expanded: false,
         };
 
@@ -2737,12 +2737,12 @@ mod tests {
             });
         "#, "test_script").unwrap();
 
-        let mut fields = std::collections::HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("photo".to_string(), FieldValue::File(None));
         let note = Note {
             id: "n2".to_string(), node_type: "PhotoNote".to_string(),
             title: "T".to_string(), parent_id: None, fields, tags: vec![],
-            created_at: 0, modified_at: 0, position: 0,
+            created_at: 0, modified_at: 0, position: 0.0,
             created_by: 0, modified_by: 0, is_expanded: false,
         };
 

--- a/krillnotes-core/src/core/scripting/schema.rs
+++ b/krillnotes-core/src/core/scripting/schema.rs
@@ -10,7 +10,7 @@ use crate::{FieldValue, KrillnotesError, Result};
 use chrono::NaiveDate;
 use rhai::{Dynamic, Engine, FnPtr, Map, AST};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Mutex};
 
 /// A stored hook entry: the Rhai closure and the AST it was defined in.
@@ -27,8 +27,8 @@ pub(super) struct HookEntry {
 /// modifications for that note, or `None` when the hook left it unchanged.
 #[derive(Debug)]
 pub struct AddChildResult {
-    pub parent: Option<(String, HashMap<String, FieldValue>)>,
-    pub child:  Option<(String, HashMap<String, FieldValue>)>,
+    pub parent: Option<(String, BTreeMap<String, FieldValue>)>,
+    pub child:  Option<(String, BTreeMap<String, FieldValue>)>,
 }
 
 /// Describes a single typed field within a note schema.
@@ -96,7 +96,7 @@ impl Schema {
     ///
     /// Returns [`KrillnotesError::ValidationFailed`] for the first required
     /// field that is empty, naming the field in the error message.
-    pub fn validate_required_fields(&self, fields: &HashMap<String, FieldValue>) -> crate::Result<()> {
+    pub fn validate_required_fields(&self, fields: &BTreeMap<String, FieldValue>) -> crate::Result<()> {
         for field_def in &self.fields {
             if !field_def.required {
                 continue;
@@ -121,8 +121,8 @@ impl Schema {
     }
 
     /// Returns a map of field names to their zero-value defaults.
-    pub fn default_fields(&self) -> HashMap<String, FieldValue> {
-        let mut fields = HashMap::new();
+    pub fn default_fields(&self) -> BTreeMap<String, FieldValue> {
+        let mut fields = BTreeMap::new();
         for field_def in &self.fields {
             let default_value = match field_def.field_type.as_str() {
                 "text" | "textarea" => FieldValue::Text(String::new()),
@@ -406,8 +406,8 @@ impl SchemaRegistry {
         note_id: &str,
         node_type: &str,
         title: &str,
-        fields: &HashMap<String, FieldValue>,
-    ) -> Result<Option<(String, HashMap<String, FieldValue>)>> {
+        fields: &BTreeMap<String, FieldValue>,
+    ) -> Result<Option<(String, BTreeMap<String, FieldValue>)>> {
         let entry = {
             let hooks = self.on_save_hooks
                 .lock()
@@ -448,7 +448,7 @@ impl SchemaRegistry {
             .and_then(|v| v.clone().try_cast::<Map>())
             .ok_or_else(|| KrillnotesError::Scripting("hook result 'fields' must be a map".to_string()))?;
 
-        let mut new_fields = HashMap::new();
+        let mut new_fields = BTreeMap::new();
         for field_def in &schema.fields {
             let dyn_val = new_fields_dyn
                 .get(field_def.name.as_str())
@@ -549,12 +549,12 @@ impl SchemaRegistry {
         parent_id: &str,
         parent_type: &str,
         parent_title: &str,
-        parent_fields: &HashMap<String, FieldValue>,
+        parent_fields: &BTreeMap<String, FieldValue>,
         child_schema: &Schema,
         child_id: &str,
         child_type: &str,
         child_title: &str,
-        child_fields: &HashMap<String, FieldValue>,
+        child_fields: &BTreeMap<String, FieldValue>,
     ) -> Result<Option<AddChildResult>> {
         let entry = {
             let hooks = self.on_add_child_hooks
@@ -616,7 +616,7 @@ impl SchemaRegistry {
             let new_fields_dyn = pm.get("fields")
                 .and_then(|v| v.clone().try_cast::<Map>())
                 .ok_or_else(|| KrillnotesError::Scripting("hook result parent 'fields' must be a map".to_string()))?;
-            let mut new_fields = HashMap::new();
+            let mut new_fields = BTreeMap::new();
             for field_def in &parent_schema.fields {
                 let dyn_val = new_fields_dyn.get(field_def.name.as_str()).cloned().unwrap_or(Dynamic::UNIT);
                 let fv = dynamic_to_field_value(dyn_val, &field_def.field_type)
@@ -636,7 +636,7 @@ impl SchemaRegistry {
             let new_fields_dyn = cm.get("fields")
                 .and_then(|v| v.clone().try_cast::<Map>())
                 .ok_or_else(|| KrillnotesError::Scripting("hook result child 'fields' must be a map".to_string()))?;
-            let mut new_fields = HashMap::new();
+            let mut new_fields = BTreeMap::new();
             for field_def in &child_schema.fields {
                 let dyn_val = new_fields_dyn.get(field_def.name.as_str()).cloned().unwrap_or(Dynamic::UNIT);
                 let fv = dynamic_to_field_value(dyn_val, &field_def.field_type)

--- a/krillnotes-core/src/core/storage.rs
+++ b/krillnotes-core/src/core/storage.rs
@@ -187,6 +187,115 @@ impl Storage {
                 CREATE INDEX IF NOT EXISTS idx_attachments_note_id ON attachments(note_id);",
             )?;
         }
+
+        // Migration: add hlc_state table, replace operations.timestamp with HLC columns,
+        // and change notes.position from INTEGER to REAL.
+        let hlc_state_exists: bool = conn.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='hlc_state'",
+            [],
+            |row| row.get::<_, i64>(0).map(|c| c > 0),
+        )?;
+        if !hlc_state_exists {
+            // Step 1: Create hlc_state table.
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS hlc_state (
+                    id INTEGER PRIMARY KEY CHECK (id = 1),
+                    wall_ms INTEGER NOT NULL,
+                    counter INTEGER NOT NULL,
+                    node_id INTEGER NOT NULL
+                );",
+            )?;
+
+            // Step 2: Recreate operations table with HLC timestamp columns.
+            // Check whether the old operations table has the standard `operation_id` column
+            // before migrating data (very old test-schema tables may only have `id`).
+            let ops_has_operation_id: bool = conn.query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('operations') WHERE name='operation_id'",
+                [],
+                |row| row.get::<_, i64>(0).map(|c| c > 0),
+            )?;
+
+            conn.execute_batch(
+                "CREATE TABLE operations_new (
+                    operation_id TEXT NOT NULL PRIMARY KEY,
+                    timestamp_wall_ms INTEGER NOT NULL DEFAULT 0,
+                    timestamp_counter INTEGER NOT NULL DEFAULT 0,
+                    timestamp_node_id INTEGER NOT NULL DEFAULT 0,
+                    device_id TEXT NOT NULL,
+                    operation_type TEXT NOT NULL,
+                    operation_data TEXT NOT NULL,
+                    synced INTEGER NOT NULL DEFAULT 0
+                );",
+            )?;
+
+            if ops_has_operation_id {
+                // Standard schema: copy data, converting Unix seconds → milliseconds.
+                conn.execute_batch(
+                    "INSERT INTO operations_new
+                        SELECT operation_id,
+                               COALESCE(timestamp, 0) * 1000,
+                               0,
+                               0,
+                               device_id,
+                               operation_type,
+                               operation_data,
+                               synced
+                        FROM operations;",
+                )?;
+            }
+            // If old table had no operation_id, it held no real data — skip data migration.
+
+            conn.execute_batch(
+                "DROP TABLE operations;
+                ALTER TABLE operations_new RENAME TO operations;
+                CREATE INDEX IF NOT EXISTS idx_operations_timestamp_wall_ms ON operations(timestamp_wall_ms);
+                CREATE INDEX IF NOT EXISTS idx_operations_synced ON operations(synced);",
+            )?;
+
+            // Step 3: Recreate notes table with position REAL.
+            // Check whether the notes table has the standard columns (test helpers may be minimal).
+            let notes_has_created_at: bool = conn.query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('notes') WHERE name='created_at'",
+                [],
+                |row| row.get::<_, i64>(0).map(|c| c > 0),
+            )?;
+
+            conn.execute_batch(
+                "CREATE TABLE notes_new (
+                    id TEXT PRIMARY KEY,
+                    title TEXT NOT NULL,
+                    node_type TEXT NOT NULL,
+                    parent_id TEXT,
+                    position REAL NOT NULL DEFAULT 0.0,
+                    created_at INTEGER NOT NULL,
+                    modified_at INTEGER NOT NULL,
+                    created_by INTEGER NOT NULL DEFAULT 0,
+                    modified_by INTEGER NOT NULL DEFAULT 0,
+                    fields_json TEXT NOT NULL DEFAULT '{}',
+                    is_expanded INTEGER DEFAULT 1,
+                    FOREIGN KEY (parent_id) REFERENCES notes(id) ON DELETE CASCADE
+                );",
+            )?;
+
+            if notes_has_created_at {
+                // Full-schema notes table: copy all rows.
+                conn.execute_batch("INSERT INTO notes_new SELECT * FROM notes;")?;
+            }
+            // Minimal test notes tables (no created_at) have no data worth migrating.
+
+            conn.execute_batch(
+                "DROP TABLE notes;
+                ALTER TABLE notes_new RENAME TO notes;
+                CREATE INDEX IF NOT EXISTS idx_notes_parent ON notes(parent_id, position);",
+            )?;
+
+            // Step 4: Seed hlc_state from existing max timestamp.
+            conn.execute_batch(
+                "INSERT OR IGNORE INTO hlc_state (id, wall_ms, counter, node_id)
+                    SELECT 1, COALESCE(MAX(timestamp_wall_ms), 0), 0, 0 FROM operations;",
+            )?;
+        }
+
         Ok(())
     }
 

--- a/krillnotes-core/src/core/undo.rs
+++ b/krillnotes-core/src/core/undo.rs
@@ -12,7 +12,7 @@
 
 use crate::{AttachmentMeta, FieldValue, Note};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 /// The inverse data needed to reverse one or more workspace mutations.
 ///
@@ -37,7 +37,7 @@ pub enum RetractInverse {
     NoteRestore {
         note_id: String,
         old_title: String,
-        old_fields: HashMap<String, FieldValue>,
+        old_fields: BTreeMap<String, FieldValue>,
         old_tags: Vec<String>,
     },
 
@@ -45,7 +45,7 @@ pub enum RetractInverse {
     PositionRestore {
         note_id: String,
         old_parent_id: Option<String>,
-        old_position: i32,
+        old_position: f64,
     },
 
     /// Inverse of `CreateUserScript` — delete the created script.
@@ -94,7 +94,7 @@ pub struct UndoResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
 
     #[test]
     fn test_retract_inverse_batch_serializes() {

--- a/krillnotes-core/src/core/workspace.rs
+++ b/krillnotes-core/src/core/workspace.rs
@@ -10,6 +10,7 @@ use crate::core::attachment::{
     decrypt_attachment, encrypt_attachment, AttachmentMeta,
 };
 use crate::core::export::WorkspaceMetadata;
+use crate::core::hlc::{HlcClock, HlcTimestamp};
 use crate::core::user_script;
 #[allow(unused_imports)]
 use crate::{
@@ -21,7 +22,7 @@ use rhai::Dynamic;
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
@@ -85,6 +86,11 @@ pub struct Workspace {
     /// is executing so that mutations called from within an undo/redo do not push
     /// spurious entries onto the undo stack.
     inside_undo: bool,
+    /// Hybrid Logical Clock for monotonically-ordered operation timestamps.
+    hlc: HlcClock,
+    /// Optional Ed25519 signing key bound to the active identity.
+    /// When `Some`, every logged operation is signed before being written.
+    signing_key: Option<ed25519_dalek::SigningKey>,
 }
 
 impl Workspace {
@@ -95,7 +101,7 @@ impl Workspace {
     ///
     /// Returns [`crate::KrillnotesError::Database`] for any SQLite failure, or
     /// [`crate::KrillnotesError::InvalidWorkspace`] if the device ID cannot be obtained.
-    pub fn create<P: AsRef<Path>>(path: P, password: &str) -> Result<Self> {
+    pub fn create<P: AsRef<Path>>(path: P, password: &str, signing_key: Option<ed25519_dalek::SigningKey>) -> Result<Self> {
         let mut storage = Storage::create(&path, password)?;
         let mut script_registry = ScriptRegistry::new()?;
         let operation_log = OperationLog::new(PurgeStrategy::LocalOnly { keep_last: 100 });
@@ -201,7 +207,7 @@ impl Workspace {
             title,
             node_type: "TextNote".to_string(),
             parent_id: None,
-            position: 0,
+            position: 0.0,
             created_at: now,
             modified_at: now,
             created_by: 0,
@@ -237,6 +243,12 @@ impl Workspace {
         )?;
         let undo_limit: usize = 50;
 
+        // Initialise HLC for this workspace.
+        let node_id = crate::core::hlc::node_id_from_device(
+            &uuid::Uuid::parse_str(&device_id).unwrap_or_else(|_| uuid::Uuid::new_v4()),
+        );
+        let hlc = HlcClock::new(node_id);
+
         let workspace = Self {
             storage,
             script_registry,
@@ -253,6 +265,8 @@ impl Workspace {
             script_redo_stack: Vec::new(),
             undo_group_buffer: None,
             inside_undo: false,
+            hlc,
+            signing_key,
         };
         let _ = workspace.write_info_json(); // best-effort; non-fatal
         Ok(workspace)
@@ -266,7 +280,7 @@ impl Workspace {
     /// incorrect, [`crate::KrillnotesError::UnencryptedWorkspace`] if the file
     /// is a plain unencrypted SQLite database, or
     /// [`crate::KrillnotesError::Database`] for any SQLite failure.
-    pub fn open<P: AsRef<Path>>(path: P, password: &str) -> Result<Self> {
+    pub fn open<P: AsRef<Path>>(path: P, password: &str, signing_key: Option<ed25519_dalek::SigningKey>) -> Result<Self> {
         let storage = Storage::open(&path, password)?;
         let script_registry = ScriptRegistry::new()?;
         let operation_log = OperationLog::new(PurgeStrategy::LocalOnly { keep_last: 100 });
@@ -332,6 +346,13 @@ impl Workspace {
             .and_then(|s| s.parse().ok())
             .unwrap_or(50);
 
+        // Load HLC state from DB (uses stored node_id if present, else derives from device_id).
+        let node_id = crate::core::hlc::node_id_from_device(
+            &uuid::Uuid::parse_str(&device_id).unwrap_or_else(|_| uuid::Uuid::new_v4()),
+        );
+        let hlc = HlcClock::load_from_db(storage.connection(), node_id)
+            .map_err(KrillnotesError::Database)?;
+
         let mut ws = Self {
             storage,
             script_registry,
@@ -348,6 +369,8 @@ impl Workspace {
             script_redo_stack: Vec::new(),
             undo_group_buffer: None,
             inside_undo: false,
+            hlc,
+            signing_key,
         };
 
         // Load enabled scripts from the workspace DB.
@@ -446,6 +469,36 @@ impl Workspace {
     /// Takes the log as an explicit parameter for the same borrow-checker reason.
     fn purge_ops_if_needed(log: &OperationLog, tx: &rusqlite::Transaction) -> Result<()> {
         log.purge_if_needed(tx)
+    }
+
+    /// Advances the HLC and returns the next timestamp.
+    ///
+    /// Call this before opening a transaction (it only updates in-memory HLC state).
+    /// Pair with [`Self::save_hlc`] inside the transaction to persist the new state.
+    fn advance_hlc(&mut self) -> HlcTimestamp {
+        self.hlc.now()
+    }
+
+    /// Persists the current HLC state to the `hlc_state` table within a transaction.
+    ///
+    /// Takes the HLC fields as a standalone parameter to avoid a borrow conflict
+    /// with the transaction (which is borrowed from `self.storage`).
+    fn save_hlc(ts: &HlcTimestamp, tx: &rusqlite::Transaction) -> Result<()> {
+        tx.execute(
+            "INSERT OR REPLACE INTO hlc_state (id, wall_ms, counter, node_id) VALUES (1, ?, ?, ?)",
+            rusqlite::params![ts.wall_ms as i64, ts.counter as i64, ts.node_id as i64],
+        )?;
+        Ok(())
+    }
+
+    /// Signs `op` in place if a signing key is present. No-op otherwise.
+    ///
+    /// Takes the signing key as an explicit parameter to avoid a borrow conflict
+    /// with the transaction (which is borrowed from `self.storage`).
+    fn sign_op_with(signing_key: &Option<ed25519_dalek::SigningKey>, op: &mut Operation) {
+        if let Some(key) = signing_key {
+            op.sign(key);
+        }
     }
 
     /// Returns `true` if there is at least one action to undo.
@@ -636,10 +689,11 @@ impl Workspace {
         let affected_note_id = apply_result?;
 
         // Write RetractOperation to the log.
+        let retract_ts = self.advance_hlc();
         let retract_op_id = uuid::Uuid::new_v4().to_string();
         let retract_op = Operation::RetractOperation {
             operation_id: retract_op_id,
-            timestamp: chrono::Utc::now().timestamp(),
+            timestamp: retract_ts,
             device_id: self.device_id.clone(),
             retracted_ids: entry.retracted_ids.clone(),
             inverse: entry.inverse.clone(),
@@ -647,6 +701,7 @@ impl Workspace {
         };
         {
             let tx = self.storage.connection_mut().transaction()?;
+            Self::save_hlc(&retract_ts, &tx)?;
             Self::log_op(&self.operation_log, &tx, &retract_op)?;
             Self::purge_ops_if_needed(&self.operation_log, &tx)?;
             tx.commit()?;
@@ -692,10 +747,11 @@ impl Workspace {
         let affected_note_id = apply_result?;
 
         // Log redo as a new RetractOperation.
+        let redo_ts = self.advance_hlc();
         let new_op_id = uuid::Uuid::new_v4().to_string();
         let redo_op = Operation::RetractOperation {
             operation_id: new_op_id,
-            timestamp: chrono::Utc::now().timestamp(),
+            timestamp: redo_ts,
             device_id: self.device_id.clone(),
             retracted_ids: entry.retracted_ids.clone(),
             inverse: entry.inverse.clone(),
@@ -703,6 +759,7 @@ impl Workspace {
         };
         {
             let tx = self.storage.connection_mut().transaction()?;
+            Self::save_hlc(&redo_ts, &tx)?;
             Self::log_op(&self.operation_log, &tx, &redo_op)?;
             Self::purge_ops_if_needed(&self.operation_log, &tx)?;
             tx.commit()?;
@@ -884,8 +941,8 @@ impl Workspace {
 
         // Determine final parent and position
         let (final_parent, final_position) = match position {
-            AddPosition::AsChild => (Some(selected.id.clone()), 0),
-            AddPosition::AsSibling => (selected.parent_id.clone(), selected.position + 1),
+            AddPosition::AsChild => (Some(selected.id.clone()), 0.0_f64),
+            AddPosition::AsSibling => (selected.parent_id.clone(), selected.position + 1.0),
         };
 
         // Validate allowed_parent_types
@@ -927,20 +984,25 @@ impl Workspace {
             None
         };
 
+        let now = chrono::Utc::now().timestamp();
         let mut note = Note {
             id: Uuid::new_v4().to_string(),
             title: "Untitled".to_string(),
             node_type: note_type.to_string(),
             parent_id: final_parent,
             position: final_position,
-            created_at: chrono::Utc::now().timestamp(),
-            modified_at: chrono::Utc::now().timestamp(),
+            created_at: now,
+            modified_at: now,
             created_by: self.current_user_id,
             modified_by: self.current_user_id,
             fields: schema.default_fields(),
             is_expanded: true,
             tags: vec![],
         };
+
+        // Advance HLC and capture signing key before the transaction borrows self.storage.
+        let ts = self.advance_hlc();
+        let signing_key = self.signing_key.clone();
 
         let tx = self.storage.connection_mut().transaction()?;
 
@@ -1002,9 +1064,10 @@ impl Workspace {
         }
 
         // Log operation
-        let op = Operation::CreateNote {
+        Self::save_hlc(&ts, &tx)?;
+        let mut op = Operation::CreateNote {
             operation_id: Uuid::new_v4().to_string(),
-            timestamp: note.created_at,
+            timestamp: ts,
             device_id: self.device_id.clone(),
             note_id: note.id.clone(),
             parent_id: note.parent_id.clone(),
@@ -1012,8 +1075,10 @@ impl Workspace {
             node_type: note.node_type.clone(),
             title: note.title.clone(),
             fields: note.fields.clone(),
-            created_by: note.created_by,
+            created_by: String::new(),
+            signature: String::new(),
         };
+        Self::sign_op_with(&signing_key, &mut op);
         Self::log_op(&self.operation_log, &tx, &op)?;
         Self::purge_ops_if_needed(&self.operation_log, &tx)?;
 
@@ -1078,8 +1143,8 @@ impl Workspace {
         let target_note = self.get_note(target_id)?;
 
         let (new_parent_id, new_position) = match position {
-            AddPosition::AsChild => (Some(target_note.id.clone()), 0i32),
-            AddPosition::AsSibling => (target_note.parent_id.clone(), target_note.position + 1),
+            AddPosition::AsChild => (Some(target_note.id.clone()), 0.0_f64),
+            AddPosition::AsSibling => (target_note.parent_id.clone(), target_note.position + 1.0),
         };
 
         // Validate allowed_parent_types for the root copy
@@ -1122,6 +1187,13 @@ impl Workspace {
 
         let now = chrono::Utc::now().timestamp();
 
+        // Pre-advance HLC once per note in the subtree, and capture signing key,
+        // before the transaction borrows self.storage mutably.
+        let subtree_timestamps: Vec<HlcTimestamp> = subtree.iter()
+            .map(|_| self.advance_hlc())
+            .collect();
+        let signing_key = self.signing_key.clone();
+
         // 4. Insert all cloned notes in a single transaction.
         let tx = self.storage.connection_mut().transaction()?;
 
@@ -1135,7 +1207,7 @@ impl Workspace {
 
         let root_new_id = id_map[source_id].clone();
 
-        for note in &subtree {
+        for (note, ts) in subtree.iter().zip(subtree_timestamps.iter()) {
             let new_id = id_map[&note.id].clone();
             let new_parent = if note.id == source_id {
                 // Root of the copy gets the paste target as parent
@@ -1165,18 +1237,21 @@ impl Workspace {
             )?;
 
             // Log a CreateNote operation for each inserted note.
-            let op = Operation::CreateNote {
+            Self::save_hlc(ts, &tx)?;
+            let mut op = Operation::CreateNote {
                 operation_id: Uuid::new_v4().to_string(),
-                timestamp: now,
+                timestamp: *ts,
                 device_id: self.device_id.clone(),
                 note_id: new_id.clone(),
                 parent_id: new_parent,
-                position: this_position,
+                position: this_position as f64,
                 node_type: note.node_type.clone(),
                 title: note.title.clone(),
                 fields: note.fields.clone(),
-                created_by: self.current_user_id,
+                created_by: String::new(),
+                signature: String::new(),
             };
+            Self::sign_op_with(&signing_key, &mut op);
             Self::log_op(&self.operation_log, &tx, &op)?;
         }
 
@@ -1216,7 +1291,7 @@ impl Workspace {
             title: "Untitled".to_string(),
             node_type: node_type.to_string(),
             parent_id: None,
-            position: 0,
+            position: 0.0,
             created_at: now,
             modified_at: now,
             created_by: self.current_user_id,
@@ -1226,6 +1301,8 @@ impl Workspace {
             tags: vec![],
         };
 
+        let ts = self.advance_hlc();
+        let signing_key = self.signing_key.clone();
         let tx = self.storage.connection_mut().transaction()?;
 
         tx.execute(
@@ -1247,9 +1324,10 @@ impl Workspace {
         )?;
 
         // Log operation
-        let op = Operation::CreateNote {
+        Self::save_hlc(&ts, &tx)?;
+        let mut op = Operation::CreateNote {
             operation_id: Uuid::new_v4().to_string(),
-            timestamp: new_note.created_at,
+            timestamp: ts,
             device_id: self.device_id.clone(),
             note_id: new_note.id.clone(),
             parent_id: new_note.parent_id.clone(),
@@ -1257,8 +1335,10 @@ impl Workspace {
             node_type: new_note.node_type.clone(),
             title: new_note.title.clone(),
             fields: new_note.fields.clone(),
-            created_by: new_note.created_by,
+            created_by: String::new(),
+            signature: String::new(),
         };
+        Self::sign_op_with(&signing_key, &mut op);
         Self::log_op(&self.operation_log, &tx, &op)?;
         Self::purge_ops_if_needed(&self.operation_log, &tx)?;
 
@@ -1280,7 +1360,7 @@ impl Workspace {
         Ok(new_note.id)
     }
 
-    /// Updates the title of `note_id` and logs an `UpdateField` operation.
+    /// Updates the title of `note_id` and logs an `UpdateNote` operation.
     ///
     /// # Errors
     ///
@@ -1288,6 +1368,8 @@ impl Workspace {
     /// the UPDATE fails.
     pub fn update_note_title(&mut self, note_id: &str, new_title: String) -> Result<()> {
         let now = chrono::Utc::now().timestamp();
+        let ts = self.advance_hlc();
+        let signing_key = self.signing_key.clone();
         let tx = self.storage.connection_mut().transaction()?;
 
         tx.execute(
@@ -1296,15 +1378,17 @@ impl Workspace {
         )?;
 
         // Log operation
-        let op = Operation::UpdateField {
+        Self::save_hlc(&ts, &tx)?;
+        let mut op = Operation::UpdateNote {
             operation_id: Uuid::new_v4().to_string(),
-            timestamp: now,
+            timestamp: ts,
             device_id: self.device_id.clone(),
             note_id: note_id.to_string(),
-            field: "title".to_string(),
-            value: crate::FieldValue::Text(new_title),
-            modified_by: self.current_user_id,
+            title: new_title,
+            modified_by: String::new(),
+            signature: String::new(),
         };
+        Self::sign_op_with(&signing_key, &mut op);
         Self::log_op(&self.operation_log, &tx, &op)?;
         Self::purge_ops_if_needed(&self.operation_log, &tx)?;
 
@@ -1325,6 +1409,9 @@ impl Workspace {
         normalised.sort();
         normalised.dedup();
 
+        let ts = self.advance_hlc();
+        let signing_key = self.signing_key.clone();
+
         let tx = self.storage.connection_mut().transaction()?;
         tx.execute("DELETE FROM note_tags WHERE note_id = ?", [note_id])?;
         for tag in &normalised {
@@ -1333,6 +1420,22 @@ impl Workspace {
                 rusqlite::params![note_id, tag],
             )?;
         }
+
+        // Log a SetTags operation so peers can replicate tag changes.
+        Self::save_hlc(&ts, &tx)?;
+        let mut op = Operation::SetTags {
+            operation_id: Uuid::new_v4().to_string(),
+            timestamp: ts,
+            device_id: self.device_id.clone(),
+            note_id: note_id.to_string(),
+            tags: normalised,
+            modified_by: String::new(),
+            signature: String::new(),
+        };
+        Self::sign_op_with(&signing_key, &mut op);
+        Self::log_op(&self.operation_log, &tx, &op)?;
+        Self::purge_ops_if_needed(&self.operation_log, &tx)?;
+
         tx.commit()?;
         Ok(())
     }
@@ -1720,10 +1823,28 @@ impl Workspace {
         // Apply creates and updates atomically if any were queued.
         if !result.creates.is_empty() || !result.updates.is_empty() {
             let now = chrono::Utc::now().timestamp();
+
+            // Pre-advance HLC once per create, plus once per update (title) and once
+            // per field within each update, before the transaction borrows self.storage.
+            let create_timestamps: Vec<HlcTimestamp> = result.creates.iter()
+                .map(|_| self.advance_hlc())
+                .collect();
+            // For updates: title + each field
+            let update_timestamps: Vec<(HlcTimestamp, Vec<HlcTimestamp>)> = result.updates.iter()
+                .map(|update| {
+                    let title_ts = self.advance_hlc();
+                    let field_tss: Vec<HlcTimestamp> = update.fields.keys()
+                        .map(|_| self.advance_hlc())
+                        .collect();
+                    (title_ts, field_tss)
+                })
+                .collect();
+            let signing_key = self.signing_key.clone();
+
             let tx = self.storage.connection_mut().transaction()?;
 
             // ── creates ────────────────────────────────────────────────────────
-            for create in &result.creates {
+            for (create, ts) in result.creates.iter().zip(create_timestamps.iter()) {
                 // Compute the next available position under the parent.
                 let position: i32 = tx.query_row(
                     "SELECT COALESCE(MAX(position), -1) + 1 FROM notes WHERE parent_id = ?1",
@@ -1753,23 +1874,26 @@ impl Workspace {
                     ],
                 )?;
 
-                let op = Operation::CreateNote {
+                Self::save_hlc(ts, &tx)?;
+                let mut op = Operation::CreateNote {
                     operation_id: Uuid::new_v4().to_string(),
-                    timestamp: now,
+                    timestamp: *ts,
                     device_id: self.device_id.clone(),
                     note_id: create.id.clone(),
                     parent_id: Some(create.parent_id.clone()),
-                    position,
+                    position: position as f64,
                     node_type: create.node_type.clone(),
                     title: create.title.clone(),
                     fields: create.fields.clone(),
-                    created_by: self.current_user_id,
+                    created_by: String::new(),
+                    signature: String::new(),
                 };
+                Self::sign_op_with(&signing_key, &mut op);
                 Self::log_op(&self.operation_log, &tx, &op)?;
             }
 
             // ── updates ────────────────────────────────────────────────────────
-            for update in &result.updates {
+            for (update, (title_ts, field_tss)) in result.updates.iter().zip(update_timestamps.iter()) {
                 let fields_json = serde_json::to_string(&update.fields)?;
 
                 tx.execute(
@@ -1786,28 +1910,33 @@ impl Workspace {
                 )?;
 
                 // Log title update
-                let title_op = Operation::UpdateField {
+                Self::save_hlc(title_ts, &tx)?;
+                let mut title_op = Operation::UpdateNote {
                     operation_id: Uuid::new_v4().to_string(),
-                    timestamp: now,
+                    timestamp: *title_ts,
                     device_id: self.device_id.clone(),
                     note_id: update.note_id.clone(),
-                    field: "title".to_string(),
-                    value: crate::FieldValue::Text(update.title.clone()),
-                    modified_by: self.current_user_id,
+                    title: update.title.clone(),
+                    modified_by: String::new(),
+                    signature: String::new(),
                 };
+                Self::sign_op_with(&signing_key, &mut title_op);
                 Self::log_op(&self.operation_log, &tx, &title_op)?;
 
                 // Log one UpdateField per field value
-                for (field_key, field_value) in &update.fields {
-                    let field_op = Operation::UpdateField {
+                for ((field_key, field_value), field_ts) in update.fields.iter().zip(field_tss.iter()) {
+                    Self::save_hlc(field_ts, &tx)?;
+                    let mut field_op = Operation::UpdateField {
                         operation_id: Uuid::new_v4().to_string(),
-                        timestamp: now,
+                        timestamp: *field_ts,
                         device_id: self.device_id.clone(),
                         note_id: update.note_id.clone(),
                         field: field_key.clone(),
                         value: field_value.clone(),
-                        modified_by: self.current_user_id,
+                        modified_by: String::new(),
+                        signature: String::new(),
                     };
+                    Self::sign_op_with(&signing_key, &mut field_op);
                     Self::log_op(&self.operation_log, &tx, &field_op)?;
                 }
             }
@@ -1819,7 +1948,7 @@ impl Workspace {
         // ── reorder path (unchanged) ───────────────────────────────────────────
         if let Some(ids) = result.reorder {
             for (position, id) in ids.iter().enumerate() {
-                self.move_note(id, Some(note_id), position as i32)?;
+                self.move_note(id, Some(note_id), position as f64)?;
             }
         }
 
@@ -1960,7 +2089,7 @@ impl Workspace {
         &mut self,
         note_id: &str,
         new_parent_id: Option<&str>,
-        new_position: i32,
+        new_position: f64,
     ) -> Result<()> {
         // 1. Self-move check
         if new_parent_id == Some(note_id) {
@@ -2044,6 +2173,8 @@ impl Workspace {
         let old_position = note.position;
 
         let now = chrono::Utc::now().timestamp();
+        let ts = self.advance_hlc();
+        let signing_key = self.signing_key.clone();
         let tx = self.storage.connection_mut().transaction()?;
 
         // 5. Close the gap in the old sibling group
@@ -2092,14 +2223,18 @@ impl Workspace {
         }
 
         // 8. Log a MoveNote operation
-        let op = Operation::MoveNote {
+        Self::save_hlc(&ts, &tx)?;
+        let mut op = Operation::MoveNote {
             operation_id: Uuid::new_v4().to_string(),
-            timestamp: now,
+            timestamp: ts,
             device_id: self.device_id.clone(),
             note_id: note_id.to_string(),
             new_parent_id: new_parent_id.map(|s| s.to_string()),
             new_position,
+            moved_by: String::new(),
+            signature: String::new(),
         };
+        Self::sign_op_with(&signing_key, &mut op);
         Self::log_op(&self.operation_log, &tx, &op)?;
         Self::purge_ops_if_needed(&self.operation_log, &tx)?;
 
@@ -2195,14 +2330,22 @@ impl Workspace {
         tx.commit()?;
 
         // Log a DeleteNote operation for the root of the deleted subtree.
-        let op = Operation::DeleteNote {
-            operation_id: op_id.clone(),
-            timestamp: chrono::Utc::now().timestamp(),
-            device_id: self.device_id.clone(),
-            note_id: note_id.to_string(),
-        };
+        // Uses a separate transaction since the deletion tx was already committed.
+        // Advance HLC and capture signing key before the second transaction borrows self.storage.
+        let ts = self.advance_hlc();
+        let signing_key = self.signing_key.clone();
         {
             let tx = self.storage.connection_mut().transaction()?;
+            Self::save_hlc(&ts, &tx)?;
+            let mut op = Operation::DeleteNote {
+                operation_id: op_id.clone(),
+                timestamp: ts,
+                device_id: self.device_id.clone(),
+                note_id: note_id.to_string(),
+                deleted_by: String::new(),
+                signature: String::new(),
+            };
+            Self::sign_op_with(&signing_key, &mut op);
             Self::log_op(&self.operation_log, &tx, &op)?;
             Self::purge_ops_if_needed(&self.operation_log, &tx)?;
             tx.commit()?;
@@ -2300,6 +2443,10 @@ impl Workspace {
         // deletion transaction (satisfies note_links.target_id ON DELETE RESTRICT).
         self.clear_links_to(note_id)?;
 
+        // Advance HLC and capture signing key before the transaction borrows self.storage.
+        let ts = self.advance_hlc();
+        let signing_key = self.signing_key.clone();
+
         let tx = self.storage.connection_mut().transaction()?;
 
         // Fetch the note's parent — surfaces NoteNotFound for missing IDs.
@@ -2340,12 +2487,16 @@ impl Workspace {
         )?;
 
         // Log a DeleteNote operation for the promoted note.
-        let op = Operation::DeleteNote {
+        Self::save_hlc(&ts, &tx)?;
+        let mut op = Operation::DeleteNote {
             operation_id: op_id.clone(),
-            timestamp: chrono::Utc::now().timestamp(),
+            timestamp: ts,
             device_id: self.device_id.clone(),
             note_id: note_id.to_string(),
+            deleted_by: String::new(),
+            signature: String::new(),
         };
+        Self::sign_op_with(&signing_key, &mut op);
         Self::log_op(&self.operation_log, &tx, &op)?;
         Self::purge_ops_if_needed(&self.operation_log, &tx)?;
 
@@ -2454,7 +2605,7 @@ impl Workspace {
         &mut self,
         note_id: &str,
         title: String,
-        fields: HashMap<String, FieldValue>,
+        fields: BTreeMap<String, FieldValue>,
     ) -> Result<Note> {
         // Capture before-state for undo.
         // Map Database errors (e.g. QueryReturnedNoRows) to NoteNotFound so that
@@ -2509,7 +2660,7 @@ impl Workspace {
                     |row| row.get(0),
                 )
                 .map_err(|_| KrillnotesError::NoteNotFound(note_id.to_string()))?;
-            let old_fields: HashMap<String, FieldValue> =
+            let old_fields: BTreeMap<String, FieldValue> =
                 serde_json::from_str(&old_fields_json).unwrap_or_default();
 
             for (key, old_val) in &old_fields {
@@ -2529,6 +2680,14 @@ impl Workspace {
         // used to populate the undo entry's retracted_ids.
         let mut emitted_op_ids: Vec<String> = Vec::new();
 
+        // Pre-advance HLC for title op + one per field, and capture signing key,
+        // before the transaction borrows self.storage mutably.
+        let title_ts = self.advance_hlc();
+        let field_timestamps: Vec<HlcTimestamp> = fields.keys()
+            .map(|_| self.advance_hlc())
+            .collect();
+        let signing_key = self.signing_key.clone();
+
         let tx = self.storage.connection_mut().transaction()?;
 
         tx.execute(
@@ -2543,34 +2702,39 @@ impl Workspace {
             return Err(KrillnotesError::NoteNotFound(note_id.to_string()));
         }
 
-        // Log an UpdateField operation for the title, consistent with
+        // Log an UpdateNote operation for the title, consistent with
         // update_note_title.
+        Self::save_hlc(&title_ts, &tx)?;
         let title_op_id = Uuid::new_v4().to_string();
         emitted_op_ids.push(title_op_id.clone());
-        let title_op = Operation::UpdateField {
+        let mut title_op = Operation::UpdateNote {
             operation_id: title_op_id,
-            timestamp: now,
+            timestamp: title_ts,
             device_id: self.device_id.clone(),
             note_id: note_id.to_string(),
-            field: "title".to_string(),
-            value: crate::FieldValue::Text(title.clone()),
-            modified_by: self.current_user_id,
+            title: title.clone(),
+            modified_by: String::new(),
+            signature: String::new(),
         };
+        Self::sign_op_with(&signing_key, &mut title_op);
         Self::log_op(&self.operation_log, &tx, &title_op)?;
 
         // Log one UpdateField operation per field value that was written.
-        for (field_key, field_value) in &fields {
+        for ((field_key, field_value), field_ts) in fields.iter().zip(field_timestamps.iter()) {
+            Self::save_hlc(field_ts, &tx)?;
             let field_op_id = Uuid::new_v4().to_string();
             emitted_op_ids.push(field_op_id.clone());
-            let field_op = Operation::UpdateField {
+            let mut field_op = Operation::UpdateField {
                 operation_id: field_op_id,
-                timestamp: now,
+                timestamp: *field_ts,
                 device_id: self.device_id.clone(),
                 note_id: note_id.to_string(),
                 field: field_key.clone(),
                 value: field_value.clone(),
-                modified_by: self.current_user_id,
+                modified_by: String::new(),
+                signature: String::new(),
             };
+            Self::sign_op_with(&signing_key, &mut field_op);
             Self::log_op(&self.operation_log, &tx, &field_op)?;
         }
 
@@ -2671,6 +2835,10 @@ impl Workspace {
             return Err(e);
         }
 
+        // Advance HLC and capture signing key before the transaction borrows self.storage.
+        let ts = self.advance_hlc();
+        let signing_key = self.signing_key.clone();
+
         let tx = self.storage.connection_mut().transaction()?;
 
         // Determine next load_order
@@ -2686,9 +2854,10 @@ impl Workspace {
         )?;
 
         // Log operation
-        let op = Operation::CreateUserScript {
+        Self::save_hlc(&ts, &tx)?;
+        let mut op = Operation::CreateUserScript {
             operation_id: Uuid::new_v4().to_string(),
-            timestamp: now,
+            timestamp: ts,
             device_id: self.device_id.clone(),
             script_id: id.clone(),
             name: fm.name.clone(),
@@ -2696,7 +2865,10 @@ impl Workspace {
             source_code: source_code.to_string(),
             load_order,
             enabled: true,
+            created_by: String::new(),
+            signature: String::new(),
         };
+        Self::sign_op_with(&signing_key, &mut op);
         Self::log_op(&self.operation_log, &tx, &op)?;
         Self::purge_ops_if_needed(&self.operation_log, &tx)?;
 
@@ -2740,6 +2912,9 @@ impl Workspace {
         let old_script = self.get_user_script(script_id)?;
 
         let now = chrono::Utc::now().timestamp();
+        // Advance HLC and capture signing key before the transaction borrows self.storage.
+        let ts = self.advance_hlc();
+        let signing_key = self.signing_key.clone();
         let tx = self.storage.connection_mut().transaction()?;
 
         let changes = tx.execute(
@@ -2759,9 +2934,10 @@ impl Workspace {
         )?;
 
         // Log operation
-        let op = Operation::UpdateUserScript {
+        Self::save_hlc(&ts, &tx)?;
+        let mut op = Operation::UpdateUserScript {
             operation_id: Uuid::new_v4().to_string(),
-            timestamp: now,
+            timestamp: ts,
             device_id: self.device_id.clone(),
             script_id: script_id.to_string(),
             name: fm.name.clone(),
@@ -2769,7 +2945,10 @@ impl Workspace {
             source_code: source_code.to_string(),
             load_order,
             enabled,
+            modified_by: String::new(),
+            signature: String::new(),
         };
+        Self::sign_op_with(&signing_key, &mut op);
         Self::log_op(&self.operation_log, &tx, &op)?;
         Self::purge_ops_if_needed(&self.operation_log, &tx)?;
 
@@ -2800,18 +2979,23 @@ impl Workspace {
         // Capture old script state BEFORE deletion for undo.
         let old_script = self.get_user_script(script_id)?;
 
-        let now = chrono::Utc::now().timestamp();
+        let ts = self.advance_hlc();
+        let signing_key = self.signing_key.clone();
         let tx = self.storage.connection_mut().transaction()?;
 
         tx.execute("DELETE FROM user_scripts WHERE id = ?", [script_id])?;
 
         // Log operation
-        let op = Operation::DeleteUserScript {
+        Self::save_hlc(&ts, &tx)?;
+        let mut op = Operation::DeleteUserScript {
             operation_id: Uuid::new_v4().to_string(),
-            timestamp: now,
+            timestamp: ts,
             device_id: self.device_id.clone(),
             script_id: script_id.to_string(),
+            deleted_by: String::new(),
+            signature: String::new(),
         };
+        Self::sign_op_with(&signing_key, &mut op);
         Self::log_op(&self.operation_log, &tx, &op)?;
         Self::purge_ops_if_needed(&self.operation_log, &tx)?;
 
@@ -2837,7 +3021,8 @@ impl Workspace {
 
     /// Toggles the enabled state of a user script and reloads.
     pub fn toggle_user_script(&mut self, script_id: &str, enabled: bool) -> Result<Vec<ScriptError>> {
-        let now = chrono::Utc::now().timestamp();
+        let ts = self.advance_hlc();
+        let signing_key = self.signing_key.clone();
         let tx = self.storage.connection_mut().transaction()?;
 
         tx.execute(
@@ -2853,9 +3038,10 @@ impl Workspace {
         )?;
 
         // Log operation
-        let op = Operation::UpdateUserScript {
+        Self::save_hlc(&ts, &tx)?;
+        let mut op = Operation::UpdateUserScript {
             operation_id: Uuid::new_v4().to_string(),
-            timestamp: now,
+            timestamp: ts,
             device_id: self.device_id.clone(),
             script_id: script_id.to_string(),
             name,
@@ -2863,7 +3049,10 @@ impl Workspace {
             source_code,
             load_order,
             enabled,
+            modified_by: String::new(),
+            signature: String::new(),
         };
+        Self::sign_op_with(&signing_key, &mut op);
         Self::log_op(&self.operation_log, &tx, &op)?;
         Self::purge_ops_if_needed(&self.operation_log, &tx)?;
 
@@ -2874,7 +3063,8 @@ impl Workspace {
 
     /// Changes the load order of a user script and reloads.
     pub fn reorder_user_script(&mut self, script_id: &str, new_load_order: i32) -> Result<Vec<ScriptError>> {
-        let now = chrono::Utc::now().timestamp();
+        let ts = self.advance_hlc();
+        let signing_key = self.signing_key.clone();
         let tx = self.storage.connection_mut().transaction()?;
 
         tx.execute(
@@ -2890,9 +3080,10 @@ impl Workspace {
         )?;
 
         // Log operation
-        let op = Operation::UpdateUserScript {
+        Self::save_hlc(&ts, &tx)?;
+        let mut op = Operation::UpdateUserScript {
             operation_id: Uuid::new_v4().to_string(),
-            timestamp: now,
+            timestamp: ts,
             device_id: self.device_id.clone(),
             script_id: script_id.to_string(),
             name,
@@ -2900,7 +3091,10 @@ impl Workspace {
             source_code,
             load_order: new_load_order,
             enabled,
+            modified_by: String::new(),
+            signature: String::new(),
         };
+        Self::sign_op_with(&signing_key, &mut op);
         Self::log_op(&self.operation_log, &tx, &op)?;
         Self::purge_ops_if_needed(&self.operation_log, &tx)?;
 
@@ -3583,7 +3777,7 @@ impl Workspace {
 ///
 /// Must be called inside an open transaction so that the link update is
 /// atomic with the note write that precedes it.
-fn sync_note_links(tx: &rusqlite::Transaction, note_id: &str, fields: &HashMap<String, FieldValue>) -> Result<()> {
+fn sync_note_links(tx: &rusqlite::Transaction, note_id: &str, fields: &BTreeMap<String, FieldValue>) -> Result<()> {
     // Clear all existing note_links rows for this source note (replace strategy).
     tx.execute("DELETE FROM note_links WHERE source_id = ?1", [note_id])?;
     // Re-insert for any non-null NoteLink fields. No duplicates possible after
@@ -3600,7 +3794,10 @@ fn sync_note_links(tx: &rusqlite::Transaction, note_id: &str, fields: &HashMap<S
 }
 
 /// Raw 12-column tuple extracted from a `notes` + `note_tags` SQLite row.
-type NoteRow = (String, String, String, Option<String>, i64, i64, i64, i64, i64, String, i64, Option<String>);
+///
+/// `position` is stored as REAL in the DB (to support fractional positions for future
+/// CRDT ordering) but the Rust API still uses `i32`; we read it as `f64` and truncate.
+type NoteRow = (String, String, String, Option<String>, f64, i64, i64, i64, i64, String, i64, Option<String>);
 
 /// Row-mapping closure for `rusqlite::Row` → raw tuple.
 ///
@@ -3612,7 +3809,7 @@ fn map_note_row(row: &rusqlite::Row) -> rusqlite::Result<NoteRow> {
         row.get::<_, String>(1)?,
         row.get::<_, String>(2)?,
         row.get::<_, Option<String>>(3)?,
-        row.get::<_, i64>(4)?,
+        row.get::<_, f64>(4)?,
         row.get::<_, i64>(5)?,
         row.get::<_, i64>(6)?,
         row.get::<_, i64>(7)?,
@@ -3639,7 +3836,7 @@ fn note_from_row_tuple(
         title,
         node_type,
         parent_id,
-        position: position as i32,
+        position,
         created_at,
         modified_at,
         created_by,
@@ -3692,13 +3889,13 @@ fn humanize(filename: &str) -> String {
 mod tests {
     use super::*;
     use crate::FieldValue;
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
     use tempfile::NamedTempFile;
 
     #[test]
     fn test_create_workspace() {
         let temp = NamedTempFile::new().unwrap();
-        let ws = Workspace::create(temp.path(), "").unwrap();
+        let ws = Workspace::create(temp.path(), "", None).unwrap();
 
         // Verify root note exists
         let count: i64 = ws
@@ -3719,7 +3916,7 @@ mod tests {
     #[test]
     fn test_create_and_get_note() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         let root = ws.list_all_notes().unwrap()[0].clone();
         let child_id = ws
@@ -3734,7 +3931,7 @@ mod tests {
     #[test]
     fn test_update_note_title() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         let root = ws.list_all_notes().unwrap()[0].clone();
         ws.update_note_title(&root.id, "New Title".to_string())
@@ -3750,13 +3947,13 @@ mod tests {
 
         // Create workspace first
         {
-            let ws = Workspace::create(temp.path(), "").unwrap();
+            let ws = Workspace::create(temp.path(), "", None).unwrap();
             let root = ws.list_all_notes().unwrap()[0].clone();
             assert_eq!(root.node_type, "TextNote");
         }
 
         // Open it
-        let ws = Workspace::open(temp.path(), "").unwrap();
+        let ws = Workspace::open(temp.path(), "", None).unwrap();
 
         // Verify we can read notes
         let notes = ws.list_all_notes().unwrap();
@@ -3767,7 +3964,7 @@ mod tests {
     #[test]
     fn test_is_expanded_defaults_to_true() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         // Check root note is expanded by default
         let root = ws.list_all_notes().unwrap()[0].clone();
@@ -3788,14 +3985,14 @@ mod tests {
 
         // Create workspace with notes
         {
-            let mut ws = Workspace::create(temp.path(), "").unwrap();
+            let mut ws = Workspace::create(temp.path(), "", None).unwrap();
             let root = ws.list_all_notes().unwrap()[0].clone();
             ws.create_note(&root.id, AddPosition::AsChild, "TextNote")
                 .unwrap();
         }
 
         // Open and verify is_expanded is true
-        let ws = Workspace::open(temp.path(), "").unwrap();
+        let ws = Workspace::open(temp.path(), "", None).unwrap();
         let notes = ws.list_all_notes().unwrap();
         assert_eq!(notes.len(), 2);
         assert!(notes[0].is_expanded, "Root note should be expanded");
@@ -3805,7 +4002,7 @@ mod tests {
     #[test]
     fn test_toggle_note_expansion() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         let root = ws.list_all_notes().unwrap()[0].clone();
         assert!(root.is_expanded, "Root should start expanded");
@@ -3824,7 +4021,7 @@ mod tests {
     #[test]
     fn test_toggle_note_expansion_with_child_notes() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         let root = ws.list_all_notes().unwrap()[0].clone();
         let child_id = ws
@@ -3845,7 +4042,7 @@ mod tests {
     #[test]
     fn test_toggle_note_expansion_nonexistent_note() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         // Try to toggle a note that doesn't exist
         let result = ws.toggle_note_expansion("nonexistent-id");
@@ -3855,7 +4052,7 @@ mod tests {
     #[test]
     fn test_set_and_get_selected_note() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         let root = ws.list_all_notes().unwrap()[0].clone();
 
@@ -3880,13 +4077,13 @@ mod tests {
 
         // Create workspace and set selection
         {
-            let mut ws = Workspace::create(temp.path(), "").unwrap();
+            let mut ws = Workspace::create(temp.path(), "", None).unwrap();
             let root = ws.list_all_notes().unwrap()[0].clone();
             ws.set_selected_note(Some(&root.id)).unwrap();
         }
 
         // Open workspace and verify selection persists
-        let ws = Workspace::open(temp.path(), "").unwrap();
+        let ws = Workspace::open(temp.path(), "", None).unwrap();
         let root = ws.list_all_notes().unwrap()[0].clone();
         let selected = ws.get_selected_note().unwrap();
         assert_eq!(selected, Some(root.id), "Selection should persist across open");
@@ -3895,7 +4092,7 @@ mod tests {
     #[test]
     fn test_set_selected_note_overwrites_previous() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         let root = ws.list_all_notes().unwrap()[0].clone();
         let child_id = ws
@@ -3916,7 +4113,7 @@ mod tests {
     #[test]
     fn test_create_note_root() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         // Delete existing root note to simulate empty workspace
         let existing_root = ws.list_all_notes().unwrap()[0].clone();
@@ -3932,14 +4129,14 @@ mod tests {
         assert_eq!(new_root.title, "Untitled");
         assert_eq!(new_root.node_type, "TextNote");
         assert_eq!(new_root.parent_id, None, "Root note should have no parent");
-        assert_eq!(new_root.position, 0, "Root note should be at position 0");
+        assert_eq!(new_root.position, 0.0, "Root note should be at position 0");
         assert!(new_root.is_expanded, "Root note should be expanded");
     }
 
     #[test]
     fn test_create_note_root_invalid_type() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         // Delete existing root note
         let existing_root = ws.list_all_notes().unwrap()[0].clone();
@@ -3956,7 +4153,7 @@ mod tests {
     #[test]
     fn test_sibling_insertion_does_not_create_duplicate_positions() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         let root = ws.list_all_notes().unwrap()[0].clone();
 
@@ -3980,7 +4177,7 @@ mod tests {
     #[test]
     fn test_get_note_with_corrupt_fields_json_returns_error() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
         let root = ws.list_all_notes().unwrap()[0].clone();
 
         // Corrupt the stored JSON directly.
@@ -3997,7 +4194,7 @@ mod tests {
     #[test]
     fn test_list_all_notes_with_corrupt_fields_json_returns_error() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
         let root = ws.list_all_notes().unwrap()[0].clone();
 
         ws.storage.connection_mut().execute(
@@ -4012,7 +4209,7 @@ mod tests {
     #[test]
     fn test_sibling_insertion_preserves_correct_order() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         let root = ws.list_all_notes().unwrap()[0].clone();
 
@@ -4027,15 +4224,15 @@ mod tests {
         let child3 = ws.get_note(&child3_id).unwrap();
 
         // Expected order: child1 (0), child3 (1), child2 (2)
-        assert_eq!(child1.position, 0, "child1 should remain at position 0");
-        assert_eq!(child3.position, 1, "child3 (inserted after child1) should be at position 1");
-        assert_eq!(child2.position, 2, "child2 should be bumped to position 2");
+        assert_eq!(child1.position, 0.0, "child1 should remain at position 0");
+        assert_eq!(child3.position, 1.0, "child3 (inserted after child1) should be at position 1");
+        assert_eq!(child2.position, 2.0, "child2 should be bumped to position 2");
     }
 
     #[test]
     fn test_update_note() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         // Get the root note
         let notes = ws.list_all_notes().unwrap();
@@ -4047,7 +4244,7 @@ mod tests {
 
         // Update the note
         let new_title = "Updated Title".to_string();
-        let mut new_fields = HashMap::new();
+        let mut new_fields = BTreeMap::new();
         new_fields.insert("body".to_string(), FieldValue::Text("Updated body".to_string()));
 
         let updated = ws.update_note(&note_id, new_title.clone(), new_fields.clone()).unwrap();
@@ -4061,16 +4258,16 @@ mod tests {
     #[test]
     fn test_update_note_not_found() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
-        let result = ws.update_note("nonexistent-id", "Title".to_string(), HashMap::new());
+        let result = ws.update_note("nonexistent-id", "Title".to_string(), BTreeMap::new());
         assert!(matches!(result, Err(KrillnotesError::NoteNotFound(_))));
     }
 
     #[test]
     fn test_count_children() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         // Get root note
         let notes = ws.list_all_notes().unwrap();
@@ -4096,7 +4293,7 @@ mod tests {
     #[test]
     fn test_delete_note_recursive() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         // Get root note
         let root = ws.list_all_notes().unwrap()[0].clone();
@@ -4127,7 +4324,7 @@ mod tests {
     #[test]
     fn test_delete_note_recursive_not_found() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
         let result = ws.delete_note_recursive("nonexistent-id");
         assert!(matches!(result, Err(KrillnotesError::NoteNotFound(_))));
     }
@@ -4135,7 +4332,7 @@ mod tests {
     #[test]
     fn test_delete_note_promote() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         // Get root note
         let root = ws.list_all_notes().unwrap()[0].clone();
@@ -4169,7 +4366,7 @@ mod tests {
     #[test]
     fn test_update_contact_rejects_empty_required_fields() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
         // Contact schema is already loaded from starter scripts.
 
         let root_id = ws.list_all_notes().unwrap()[0].id.clone();
@@ -4182,7 +4379,7 @@ mod tests {
             .unwrap();
 
         // first_name is required but empty — save must fail.
-        let mut fields = HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("first_name".to_string(), FieldValue::Text("".to_string()));
         fields.insert("middle_name".to_string(), FieldValue::Text("".to_string()));
         fields.insert("last_name".to_string(), FieldValue::Text("Smith".to_string()));
@@ -4207,7 +4404,7 @@ mod tests {
     #[test]
     fn test_delete_note_promote_not_found() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         let result = ws.delete_note_promote("nonexistent-id");
         assert!(matches!(result, Err(KrillnotesError::NoteNotFound(_))));
@@ -4220,7 +4417,7 @@ mod tests {
     #[test]
     fn test_delete_note_promote_no_position_collision() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         // Build tree: root -> sib1 (pos 0) -> child1 (pos 0)
         //                                   -> child2 (pos 1)
@@ -4242,8 +4439,8 @@ mod tests {
 
         // Gather positions of the surviving root-level notes
         let root_level: Vec<_> = notes.iter().filter(|n| n.parent_id == Some(root.id.clone())).collect();
-        let mut positions: Vec<i32> = root_level.iter().map(|n| n.position).collect();
-        positions.sort();
+        let mut positions: Vec<f64> = root_level.iter().map(|n| n.position).collect();
+        positions.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
         // All positions must be unique
         let unique_count = {
@@ -4266,7 +4463,7 @@ mod tests {
     #[test]
     fn test_update_contact_derives_title_from_hook() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
         // Contact schema is already loaded from starter scripts.
 
         let notes = ws.list_all_notes().unwrap();
@@ -4280,7 +4477,7 @@ mod tests {
             .create_note(&folder_id, AddPosition::AsChild, "Contact")
             .unwrap();
 
-        let mut fields = HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("first_name".to_string(), FieldValue::Text("Alice".to_string()));
         fields.insert("middle_name".to_string(), FieldValue::Text("".to_string()));
         fields.insert("last_name".to_string(), FieldValue::Text("Walker".to_string()));
@@ -4311,7 +4508,7 @@ mod tests {
     #[test]
     fn test_workspace_created_with_starter_scripts() {
         let temp = NamedTempFile::new().unwrap();
-        let workspace = Workspace::create(temp.path(), "").unwrap();
+        let workspace = Workspace::create(temp.path(), "", None).unwrap();
         let scripts = workspace.list_user_scripts().unwrap();
         assert!(!scripts.is_empty(), "New workspace should have starter scripts");
         // Verify first starter script is TextNote
@@ -4323,7 +4520,7 @@ mod tests {
     #[test]
     fn test_create_user_script() {
         let temp = NamedTempFile::new().unwrap();
-        let mut workspace = Workspace::create(temp.path(), "").unwrap();
+        let mut workspace = Workspace::create(temp.path(), "", None).unwrap();
         let starter_count = workspace.list_user_scripts().unwrap().len();
         let source = "// @name: Test Script\n// @description: A test\nschema(\"TestType\", #{ fields: [] });";
         let (script, errors) = workspace.create_user_script(source).unwrap();
@@ -4337,7 +4534,7 @@ mod tests {
     #[test]
     fn test_create_user_script_missing_name_fails() {
         let temp = NamedTempFile::new().unwrap();
-        let mut workspace = Workspace::create(temp.path(), "").unwrap();
+        let mut workspace = Workspace::create(temp.path(), "", None).unwrap();
         let source = "// no name here\nschema(\"X\", #{ fields: [] });";
         let result = workspace.create_user_script(source);
         assert!(result.is_err());
@@ -4346,7 +4543,7 @@ mod tests {
     #[test]
     fn test_update_user_script() {
         let temp = NamedTempFile::new().unwrap();
-        let mut workspace = Workspace::create(temp.path(), "").unwrap();
+        let mut workspace = Workspace::create(temp.path(), "", None).unwrap();
         let source = "// @name: Original\nschema(\"Orig\", #{ fields: [] });";
         let (script, _) = workspace.create_user_script(source).unwrap();
 
@@ -4359,7 +4556,7 @@ mod tests {
     #[test]
     fn test_delete_user_script() {
         let temp = NamedTempFile::new().unwrap();
-        let mut workspace = Workspace::create(temp.path(), "").unwrap();
+        let mut workspace = Workspace::create(temp.path(), "", None).unwrap();
         let initial_count = workspace.list_user_scripts().unwrap().len();
         let source = "// @name: ToDelete\nschema(\"Del\", #{ fields: [] });";
         let (script, _) = workspace.create_user_script(source).unwrap();
@@ -4372,7 +4569,7 @@ mod tests {
     #[test]
     fn test_toggle_user_script() {
         let temp = NamedTempFile::new().unwrap();
-        let mut workspace = Workspace::create(temp.path(), "").unwrap();
+        let mut workspace = Workspace::create(temp.path(), "", None).unwrap();
         let source = "// @name: Toggle\nschema(\"Tog\", #{ fields: [] });";
         let (script, _) = workspace.create_user_script(source).unwrap();
         assert!(script.enabled);
@@ -4385,7 +4582,7 @@ mod tests {
     #[test]
     fn test_user_scripts_sorted_by_load_order() {
         let temp = NamedTempFile::new().unwrap();
-        let mut workspace = Workspace::create(temp.path(), "").unwrap();
+        let mut workspace = Workspace::create(temp.path(), "", None).unwrap();
         let starter_count = workspace.list_user_scripts().unwrap().len();
 
         let s1 = "// @name: Second\nschema(\"S2\", #{ fields: [] });";
@@ -4406,13 +4603,13 @@ mod tests {
         let temp = NamedTempFile::new().unwrap();
 
         {
-            let mut workspace = Workspace::create(temp.path(), "").unwrap();
+            let mut workspace = Workspace::create(temp.path(), "", None).unwrap();
             workspace.create_user_script(
                 "// @name: TestOpen\nschema(\"OpenType\", #{ fields: [#{ name: \"x\", type: \"text\" }] });"
             ).unwrap(); // (UserScript, Vec<ScriptError>) — result not inspected here
         }
 
-        let workspace = Workspace::open(temp.path(), "").unwrap();
+        let workspace = Workspace::open(temp.path(), "", None).unwrap();
         assert!(workspace.script_registry().get_schema("OpenType").is_ok());
     }
 
@@ -4421,21 +4618,21 @@ mod tests {
         let temp = NamedTempFile::new().unwrap();
 
         {
-            let mut workspace = Workspace::create(temp.path(), "").unwrap();
+            let mut workspace = Workspace::create(temp.path(), "", None).unwrap();
             let (script, _) = workspace.create_user_script(
                 "// @name: Disabled\nschema(\"DisType\", #{ fields: [#{ name: \"x\", type: \"text\" }] });"
             ).unwrap();
             workspace.toggle_user_script(&script.id, false).unwrap();
         }
 
-        let workspace = Workspace::open(temp.path(), "").unwrap();
+        let workspace = Workspace::open(temp.path(), "", None).unwrap();
         assert!(workspace.script_registry().get_schema("DisType").is_err());
     }
 
     #[test]
     fn test_delete_note_with_strategy() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         let root = ws.list_all_notes().unwrap()[0].clone();
         let child_id = ws.create_note(&root.id, AddPosition::AsChild, "TextNote").unwrap();
@@ -4467,7 +4664,7 @@ mod tests {
     /// preserves that order: `child_ids[0]` is at position 0, etc.
     fn setup_with_children(n: usize) -> (Workspace, String, Vec<String>, NamedTempFile) {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
         let root = ws.list_all_notes().unwrap()[0].clone();
         let mut child_ids: Vec<String> = Vec::new();
         for i in 0..n {
@@ -4486,41 +4683,41 @@ mod tests {
     #[test]
     fn test_move_note_reorder_siblings() {
         let (mut ws, root_id, children, _temp) = setup_with_children(3);
-        ws.move_note(&children[2], Some(&root_id), 0).unwrap();
+        ws.move_note(&children[2], Some(&root_id), 0.0).unwrap();
         let kids = ws.get_children(&root_id).unwrap();
         assert_eq!(kids[0].id, children[2]);
         assert_eq!(kids[1].id, children[0]);
         assert_eq!(kids[2].id, children[1]);
         for (i, kid) in kids.iter().enumerate() {
-            assert_eq!(kid.position, i as i32, "Position mismatch at index {i}");
+            assert_eq!(kid.position, i as f64, "Position mismatch at index {i}");
         }
     }
 
     #[test]
     fn test_move_note_to_different_parent() {
         let (mut ws, root_id, children, _temp) = setup_with_children(2);
-        ws.move_note(&children[1], Some(&children[0]), 0).unwrap();
+        ws.move_note(&children[1], Some(&children[0]), 0.0).unwrap();
         let root_kids = ws.get_children(&root_id).unwrap();
         assert_eq!(root_kids.len(), 1);
         assert_eq!(root_kids[0].id, children[0]);
-        assert_eq!(root_kids[0].position, 0);
+        assert_eq!(root_kids[0].position, 0.0);
         let grandkids = ws.get_children(&children[0]).unwrap();
         assert_eq!(grandkids.len(), 1);
         assert_eq!(grandkids[0].id, children[1]);
-        assert_eq!(grandkids[0].position, 0);
+        assert_eq!(grandkids[0].position, 0.0);
     }
 
     #[test]
     fn test_move_note_to_root() {
         let (mut ws, root_id, children, _temp) = setup_with_children(2);
-        ws.move_note(&children[0], None, 1).unwrap();
+        ws.move_note(&children[0], None, 1.0).unwrap();
         let root_kids = ws.get_children(&root_id).unwrap();
         assert_eq!(root_kids.len(), 1);
         assert_eq!(root_kids[0].id, children[1]);
-        assert_eq!(root_kids[0].position, 0);
+        assert_eq!(root_kids[0].position, 0.0);
         let moved = ws.get_note(&children[0]).unwrap();
         assert_eq!(moved.parent_id, None);
-        assert_eq!(moved.position, 1);
+        assert_eq!(moved.position, 1.0);
     }
 
     #[test]
@@ -4529,7 +4726,7 @@ mod tests {
         let grandchild_id = ws
             .create_note(&children[0], AddPosition::AsChild, "TextNote")
             .unwrap();
-        let result = ws.move_note(&children[0], Some(&grandchild_id), 0);
+        let result = ws.move_note(&children[0], Some(&grandchild_id), 0.0);
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.to_string().contains("cycle"), "Expected cycle error, got: {err}");
@@ -4538,7 +4735,7 @@ mod tests {
     #[test]
     fn test_move_note_prevents_self_move() {
         let (mut ws, _root_id, children, _temp) = setup_with_children(1);
-        let result = ws.move_note(&children[0], Some(&children[0]), 0);
+        let result = ws.move_note(&children[0], Some(&children[0]), 0.0);
         assert!(result.is_err());
     }
 
@@ -4546,7 +4743,7 @@ mod tests {
     fn test_move_note_logs_operation() {
         // The operation log is always active — MoveNote must be recorded.
         let (mut ws, root_id, children, _temp) = setup_with_children(2);
-        ws.move_note(&children[1], Some(&root_id), 0).unwrap();
+        ws.move_note(&children[1], Some(&root_id), 0.0).unwrap();
         let ops = ws.list_operations(None, None, None).unwrap();
         let move_ops: Vec<_> = ops.iter().filter(|o| o.operation_type == "MoveNote").collect();
         assert_eq!(move_ops.len(), 1, "Expected one MoveNote operation in always-on log");
@@ -4555,18 +4752,18 @@ mod tests {
     #[test]
     fn test_move_note_positions_gapless_after_cross_parent_move() {
         let (mut ws, root_id, children, _temp) = setup_with_children(4);
-        ws.move_note(&children[1], Some(&children[0]), 0).unwrap();
+        ws.move_note(&children[1], Some(&children[0]), 0.0).unwrap();
         let root_kids = ws.get_children(&root_id).unwrap();
         assert_eq!(root_kids.len(), 3);
         for (i, kid) in root_kids.iter().enumerate() {
-            assert_eq!(kid.position, i as i32, "Gap at index {i}");
+            assert_eq!(kid.position, i as f64, "Gap at index {i}");
         }
     }
 
     #[test]
     fn test_run_view_hook_returns_html_without_hook() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         // Load a schema with a textarea field but no on_view hook.
         ws.create_user_script(
@@ -4587,7 +4784,7 @@ schema("Memo", #{
             .unwrap();
 
         // Update the note's body field with Markdown content.
-        let mut fields = HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("body".into(), FieldValue::Text("**hello**".into()));
         ws.update_note(&note_id, "My Memo".into(), fields).unwrap();
 
@@ -4602,7 +4799,7 @@ schema("Memo", #{
     #[test]
     fn test_create_user_script_rejects_compile_error() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         let initial_count = ws.list_user_scripts().unwrap().len();
 
@@ -4619,7 +4816,7 @@ schema("Memo", #{
     #[test]
     fn test_update_user_script_rejects_compile_error() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         let initial_count = ws.list_user_scripts().unwrap().len();
 
@@ -4646,7 +4843,7 @@ schema("Memo", #{
     #[test]
     fn test_create_workspace_with_password() {
         let temp = NamedTempFile::new().unwrap();
-        let ws = Workspace::create(temp.path(), "secret").unwrap();
+        let ws = Workspace::create(temp.path(), "secret", None).unwrap();
         // Should have at least one note (the root note)
         assert!(!ws.list_all_notes().unwrap().is_empty());
     }
@@ -4654,23 +4851,23 @@ schema("Memo", #{
     #[test]
     fn test_open_workspace_with_password() {
         let temp = NamedTempFile::new().unwrap();
-        Workspace::create(temp.path(), "secret").unwrap();
-        let ws = Workspace::open(temp.path(), "secret").unwrap();
+        Workspace::create(temp.path(), "secret", None).unwrap();
+        let ws = Workspace::open(temp.path(), "secret", None).unwrap();
         assert!(!ws.list_all_notes().unwrap().is_empty());
     }
 
     #[test]
     fn test_open_workspace_wrong_password() {
         let temp = NamedTempFile::new().unwrap();
-        Workspace::create(temp.path(), "secret").unwrap();
-        let result = Workspace::open(temp.path(), "wrong");
+        Workspace::create(temp.path(), "secret", None).unwrap();
+        let result = Workspace::open(temp.path(), "wrong", None);
         assert!(matches!(result, Err(KrillnotesError::WrongPassword)));
     }
 
     #[test]
     fn test_deep_copy_note_as_child() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         // root → child
         let root = ws.list_all_notes().unwrap()[0].clone();
@@ -4702,7 +4899,7 @@ schema("Memo", #{
     #[test]
     fn test_deep_copy_note_recursive() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         // root → note_a → note_b
         let root = ws.list_all_notes().unwrap()[0].clone();
@@ -4747,7 +4944,7 @@ schema("Memo", #{
     #[test]
     fn test_on_add_child_hook_fires_on_create() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         ws.script_registry_mut().load_script(r#"
             schema("Folder", #{
@@ -4779,7 +4976,7 @@ schema("Memo", #{
     #[test]
     fn test_on_add_child_hook_fires_for_sibling_under_hooked_parent() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         ws.script_registry_mut().load_script(r#"
             schema("Folder", #{
@@ -4810,7 +5007,7 @@ schema("Memo", #{
     #[test]
     fn test_on_add_child_hook_does_not_fire_for_root_level_creation() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         // No on_add_child hook registered — creating a sibling of root should work silently
         let root = ws.list_all_notes().unwrap()[0].clone();
@@ -4822,7 +5019,7 @@ schema("Memo", #{
     #[test]
     fn test_on_add_child_hook_fires_on_move() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         ws.script_registry_mut().load_script(r#"
             schema("Folder", #{
@@ -4846,7 +5043,7 @@ schema("Memo", #{
         let item_id   = ws.create_note(&root.id, AddPosition::AsChild, "Item").unwrap();
 
         // Move Item under Folder — hook should fire
-        ws.move_note(&item_id, Some(&folder_id), 0).unwrap();
+        ws.move_note(&item_id, Some(&folder_id), 0.0).unwrap();
 
         let folder = ws.get_note(&folder_id).unwrap();
         assert_eq!(folder.title, "Folder (1)");
@@ -4858,7 +5055,7 @@ schema("Memo", #{
     #[test]
     fn test_run_tree_action_reorders_children() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         let root = ws.list_all_notes().unwrap()[0].clone();
         let parent_id = ws.create_note(&root.id, AddPosition::AsChild, "TextNote").unwrap();
@@ -4898,7 +5095,7 @@ add_tree_action("Sort A→Z", ["TextNote"], |note| {
     #[test]
     fn test_tree_action_create_note_writes_to_db() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         ws.create_user_script(r#"
 // @name: CreateAction
@@ -4929,7 +5126,7 @@ add_tree_action("Add Item", ["TaFolder"], |folder| {
     #[test]
     fn test_tree_action_update_note_writes_to_db() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         ws.create_user_script(r#"
 // @name: UpdateAction
@@ -4957,7 +5154,7 @@ add_tree_action("Mark Done", ["TaTask"], |note| {
     #[test]
     fn test_tree_action_nested_create_builds_subtree() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         ws.create_user_script(r#"
 // @name: NestedCreate
@@ -4992,7 +5189,7 @@ add_tree_action("Add Sprint With Task", ["TaSprint"], |sprint| {
     #[test]
     fn test_tree_action_error_rolls_back_all_writes() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         ws.create_user_script(r#"
 // @name: ErrorAction
@@ -5020,7 +5217,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     #[test]
     fn test_note_tags_round_trip() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
         let root = ws.list_all_notes().unwrap()[0].clone();
         assert!(root.tags.is_empty());
 
@@ -5032,14 +5229,14 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     #[test]
     fn test_get_all_tags_empty() {
         let temp = NamedTempFile::new().unwrap();
-        let ws = Workspace::create(temp.path(), "").unwrap();
+        let ws = Workspace::create(temp.path(), "", None).unwrap();
         assert!(ws.get_all_tags().unwrap().is_empty());
     }
 
     #[test]
     fn test_get_all_tags_sorted_distinct() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
         let root = ws.list_all_notes().unwrap()[0].clone();
         let child_id = ws.create_note(&root.id, AddPosition::AsChild, "TextNote").unwrap();
         ws.update_note_tags(&root.id, vec!["rust".into(), "design".into()]).unwrap();
@@ -5051,7 +5248,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     #[test]
     fn test_get_notes_for_tag() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
         let root = ws.list_all_notes().unwrap()[0].clone();
         let child_id = ws.create_note(&root.id, AddPosition::AsChild, "TextNote").unwrap();
         ws.update_note_tags(&root.id, vec!["rust".into()]).unwrap();
@@ -5073,7 +5270,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     #[test]
     fn test_update_note_tags_replaces_existing() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
         let root = ws.list_all_notes().unwrap()[0].clone();
         ws.update_note_tags(&root.id, vec!["old".into()]).unwrap();
         ws.update_note_tags(&root.id, vec!["new".into()]).unwrap();
@@ -5084,7 +5281,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     #[test]
     fn test_update_note_tags_normalises() {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
         let root = ws.list_all_notes().unwrap()[0].clone();
         ws.update_note_tags(&root.id, vec!["  Rust  ".into(), "RUST".into(), "rust".into()]).unwrap();
         let note = ws.get_note(&root.id).unwrap();
@@ -5097,7 +5294,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     /// Returns the workspace ready to use.
     fn create_test_workspace_with_schema(schema_script: &str) -> Workspace {
         let temp = NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
         // Wrap the bare schema call in the required front matter so create_user_script accepts it.
         let source = format!("// @name: TestSchema\n{schema_script}");
         ws.create_user_script(&source).unwrap();
@@ -5122,7 +5319,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
         let target = create_note_with_type(&mut ws, "LinkTestType");
         let source = create_note_with_type(&mut ws, "LinkTestType");
 
-        let mut fields = HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("link".into(), FieldValue::NoteLink(Some(target.id.clone())));
         ws.update_note(&source.id, source.title.clone(), fields).unwrap();
 
@@ -5143,11 +5340,11 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
         let target = create_note_with_type(&mut ws, "LinkTestType");
         let source = create_note_with_type(&mut ws, "LinkTestType");
 
-        let mut fields = HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("link".into(), FieldValue::NoteLink(Some(target.id.clone())));
         ws.update_note(&source.id, source.title.clone(), fields).unwrap();
 
-        let mut fields2 = HashMap::new();
+        let mut fields2 = BTreeMap::new();
         fields2.insert("link".into(), FieldValue::NoteLink(None));
         ws.update_note(&source.id, source.title.clone(), fields2).unwrap();
 
@@ -5168,7 +5365,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
         let target = create_note_with_type(&mut ws, "LinkTestType");
         let source = create_note_with_type(&mut ws, "LinkTestType");
 
-        let mut fields = HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("link".into(), FieldValue::NoteLink(Some(target.id.clone())));
         ws.update_note(&source.id, source.title.clone(), fields).unwrap();
 
@@ -5197,7 +5394,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
         let target = create_note_with_type(&mut ws, "LinkTestType");
         let source = create_note_with_type(&mut ws, "LinkTestType");
 
-        let mut fields = HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("link".into(), FieldValue::NoteLink(Some(target.id.clone())));
         ws.update_note(&source.id, source.title.clone(), fields).unwrap();
 
@@ -5220,7 +5417,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
         let child = ws.get_note(&child_id).unwrap();
         let observer = create_note_with_type(&mut ws, "LinkTestType");
 
-        let mut fields = HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("link".into(), FieldValue::NoteLink(Some(child.id.clone())));
         ws.update_note(&observer.id, observer.title.clone(), fields).unwrap();
 
@@ -5245,7 +5442,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
         let source2 = create_note_with_type(&mut ws, "LinkTestType");
 
         for source in [&source1, &source2] {
-            let mut fields = HashMap::new();
+            let mut fields = BTreeMap::new();
             fields.insert("link".into(), FieldValue::NoteLink(Some(target.id.clone())));
             ws.update_note(&source.id, source.title.clone(), fields.clone()).unwrap();
         }
@@ -5275,7 +5472,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
             r#"schema("LinkTestType", #{ fields: [] })"#
         );
         let note = create_note_with_type(&mut ws, "LinkTestType");
-        ws.update_note(&note.id, "Fix login bug".into(), HashMap::new()).unwrap();
+        ws.update_note(&note.id, "Fix login bug".into(), BTreeMap::new()).unwrap();
 
         let results = ws.search_notes("login", None).unwrap();
         assert_eq!(results.len(), 1);
@@ -5288,9 +5485,9 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
             r#"schema("TaskNote", #{ fields: [] }); schema("OtherNote", #{ fields: [] })"#
         );
         let task = create_note_with_type(&mut ws, "TaskNote");
-        ws.update_note(&task.id, "login task".into(), HashMap::new()).unwrap();
+        ws.update_note(&task.id, "login task".into(), BTreeMap::new()).unwrap();
         let other = create_note_with_type(&mut ws, "OtherNote");
-        ws.update_note(&other.id, "login other".into(), HashMap::new()).unwrap();
+        ws.update_note(&other.id, "login other".into(), BTreeMap::new()).unwrap();
 
         let results = ws.search_notes("login", Some("TaskNote")).unwrap();
         assert_eq!(results.len(), 1);
@@ -5303,7 +5500,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
             r#"schema("ContactNote", #{ fields: [#{ name: "email", type: "email" }] })"#
         );
         let c = create_note_with_type(&mut ws, "ContactNote");
-        let mut fields = HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("email".into(), FieldValue::Email("alice@example.com".into()));
         ws.update_note(&c.id, "Alice".into(), fields).unwrap();
 
@@ -5322,7 +5519,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
         let target = create_note_with_type(&mut ws, "LinkTestType");
         let source = create_note_with_type(&mut ws, "LinkTestType");
 
-        let mut fields = HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("link".into(), FieldValue::NoteLink(Some(target.id.clone())));
         ws.update_note(&source.id, source.title.clone(), fields).unwrap();
 
@@ -5345,7 +5542,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn operations_log_always_records_create_note() {
         // The operation log is always active — every mutation must be recorded.
         let temp = tempfile::NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
         let root = ws.list_all_notes().unwrap()[0].clone();
         ws.create_note(&root.id, AddPosition::AsChild, "TextNote").unwrap();
         let ops = ws.list_operations(None, None, None).unwrap();
@@ -5358,7 +5555,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_workspace_has_attachment_key_when_encrypted() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("notes.db");
-        let ws = Workspace::create(&db_path, "hunter2").unwrap();
+        let ws = Workspace::create(&db_path, "hunter2", None).unwrap();
         assert!(ws.attachment_key().is_some(), "Encrypted workspace must have attachment_key");
     }
 
@@ -5366,7 +5563,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_workspace_has_no_attachment_key_when_unencrypted() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("notes.db");
-        let ws = Workspace::create(&db_path, "").unwrap();
+        let ws = Workspace::create(&db_path, "", None).unwrap();
         assert!(ws.attachment_key().is_none(), "Unencrypted workspace must have no attachment_key");
     }
 
@@ -5374,7 +5571,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_workspace_creates_attachments_directory() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("notes.db");
-        Workspace::create(&db_path, "").unwrap();
+        Workspace::create(&db_path, "", None).unwrap();
         assert!(dir.path().join("attachments").is_dir());
     }
 
@@ -5382,10 +5579,10 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_workspace_attachment_key_stable_across_open() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("notes.db");
-        let ws1 = Workspace::create(&db_path, "mypass").unwrap();
+        let ws1 = Workspace::create(&db_path, "mypass", None).unwrap();
         let key1 = ws1.attachment_key().unwrap().clone();
         drop(ws1);
-        let ws2 = Workspace::open(&db_path, "mypass").unwrap();
+        let ws2 = Workspace::open(&db_path, "mypass", None).unwrap();
         let key2 = ws2.attachment_key().unwrap();
         assert_eq!(key1, *key2, "Key must be derived deterministically from password + workspace_id");
     }
@@ -5393,7 +5590,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     #[test]
     fn test_get_set_workspace_metadata() {
         let temp = tempfile::NamedTempFile::new().unwrap();
-        let mut ws = Workspace::create(temp.path(), "").unwrap();
+        let mut ws = Workspace::create(temp.path(), "", None).unwrap();
 
         // Fresh workspace returns default (no error)
         let initial = ws.get_workspace_metadata().unwrap();
@@ -5438,7 +5635,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_attach_file_stores_metadata_and_file() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("notes.db");
-        let mut ws = Workspace::create(&db_path, "testpass").unwrap();
+        let mut ws = Workspace::create(&db_path, "testpass", None).unwrap();
         let notes = ws.list_all_notes().unwrap();
         let root_id = &notes[0].id;
 
@@ -5455,7 +5652,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_get_attachment_bytes_decrypts_correctly() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("notes.db");
-        let mut ws = Workspace::create(&db_path, "testpass").unwrap();
+        let mut ws = Workspace::create(&db_path, "testpass", None).unwrap();
         let root_id = ws.list_all_notes().unwrap()[0].id.clone();
 
         let data = b"secret file content";
@@ -5468,7 +5665,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_get_attachments_returns_metadata_list() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("notes.db");
-        let mut ws = Workspace::create(&db_path, "").unwrap();
+        let mut ws = Workspace::create(&db_path, "", None).unwrap();
         let root_id = ws.list_all_notes().unwrap()[0].id.clone();
 
         ws.attach_file(&root_id, "a.pdf", None, b"data a").unwrap();
@@ -5485,7 +5682,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_delete_attachment_soft_deletes() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("notes.db");
-        let mut ws = Workspace::create(&db_path, "testpass").unwrap();
+        let mut ws = Workspace::create(&db_path, "testpass", None).unwrap();
         let root_id = ws.list_all_notes().unwrap()[0].id.clone();
 
         let meta = ws.attach_file(&root_id, "bye.txt", None, b"temp").unwrap();
@@ -5507,7 +5704,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_attach_file_enforces_size_limit() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("notes.db");
-        let mut ws = Workspace::create(&db_path, "").unwrap();
+        let mut ws = Workspace::create(&db_path, "", None).unwrap();
         let root_id = ws.list_all_notes().unwrap()[0].id.clone();
 
         ws.set_attachment_max_size_bytes(Some(10)).unwrap();
@@ -5520,7 +5717,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_update_note_cleans_up_replaced_file_field() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("notes.db");
-        let mut ws = Workspace::create(&db_path, "").unwrap();
+        let mut ws = Workspace::create(&db_path, "", None).unwrap();
 
         // Use the root TextNote that is always created on workspace init.
         let root_id = ws.list_all_notes().unwrap()[0].id.clone();
@@ -5551,7 +5748,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_operation_log_always_records() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.krillnotes");
-        let mut ws = Workspace::create(&path, "").unwrap();
+        let mut ws = Workspace::create(&path, "", None).unwrap();
         let root_id = ws.create_note_root("TextNote").unwrap();
 
         // The operation log should record the CreateNote even without sync.
@@ -5565,7 +5762,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_update_note_cleans_up_cleared_file_field() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("notes.db");
-        let mut ws = Workspace::create(&db_path, "").unwrap();
+        let mut ws = Workspace::create(&db_path, "", None).unwrap();
 
         let root_id = ws.list_all_notes().unwrap()[0].id.clone();
 
@@ -5588,7 +5785,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_can_undo_initially_false() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.krillnotes");
-        let ws = Workspace::create(&path, "").unwrap();
+        let ws = Workspace::create(&path, "", None).unwrap();
         assert!(!ws.can_undo());
         assert!(!ws.can_redo());
     }
@@ -5597,7 +5794,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_collect_subtree_notes() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.krillnotes");
-        let mut ws = Workspace::create(&path, "").unwrap();
+        let mut ws = Workspace::create(&path, "", None).unwrap();
         let root_id = ws.create_note_root("TextNote").unwrap();
         let child_id = ws.create_note(&root_id, AddPosition::AsChild, "TextNote").unwrap();
         let _grandchild = ws.create_note(&child_id, AddPosition::AsChild, "TextNote").unwrap();
@@ -5612,7 +5809,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_undo_group_collapses_to_one_entry() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.krillnotes");
-        let mut ws = Workspace::create(&path, "").unwrap();
+        let mut ws = Workspace::create(&path, "", None).unwrap();
         let root_id = ws.create_note_root("TextNote").unwrap();
         // Clear the undo entry from root creation
         ws.undo_stack.clear();
@@ -5633,7 +5830,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_undo_create_note() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.krillnotes");
-        let mut ws = Workspace::create(&path, "").unwrap();
+        let mut ws = Workspace::create(&path, "", None).unwrap();
         let root_id = ws.create_note_root("TextNote").unwrap();
         ws.undo_stack.clear(); // ignore root creation
 
@@ -5649,11 +5846,11 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_undo_update_note_restores_old_title() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.krillnotes");
-        let mut ws = Workspace::create(&path, "").unwrap();
+        let mut ws = Workspace::create(&path, "", None).unwrap();
         let root_id = ws.create_note_root("TextNote").unwrap();
         ws.undo_stack.clear();
 
-        ws.update_note(&root_id, "New Title".into(), HashMap::new()).unwrap();
+        ws.update_note(&root_id, "New Title".into(), BTreeMap::new()).unwrap();
         assert!(ws.can_undo());
 
         // Check undo entry inverse
@@ -5670,7 +5867,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_undo_delete_note_restores_subtree() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.krillnotes");
-        let mut ws = Workspace::create(&path, "").unwrap();
+        let mut ws = Workspace::create(&path, "", None).unwrap();
         let root_id = ws.create_note_root("TextNote").unwrap();
         let child_id = ws.create_note(&root_id, AddPosition::AsChild, "TextNote").unwrap();
         ws.undo_stack.clear();
@@ -5687,14 +5884,14 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_undo_move_note_restores_position() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.krillnotes");
-        let mut ws = Workspace::create(&path, "").unwrap();
+        let mut ws = Workspace::create(&path, "", None).unwrap();
         let root_id = ws.create_note_root("TextNote").unwrap();
         let child_id = ws.create_note(&root_id, AddPosition::AsChild, "TextNote").unwrap();
         let sibling_id = ws.create_note(&root_id, AddPosition::AsChild, "TextNote").unwrap();
         ws.undo_stack.clear();
 
         let old_note = ws.get_note(&sibling_id).unwrap();
-        ws.move_note(&sibling_id, Some(&child_id), 0).unwrap();
+        ws.move_note(&sibling_id, Some(&child_id), 0.0).unwrap();
 
         assert!(ws.can_undo());
         match &ws.undo_stack[0].inverse {
@@ -5711,7 +5908,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_undo_delete_script_restores_it() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.krillnotes");
-        let mut ws = Workspace::create(&path, "").unwrap();
+        let mut ws = Workspace::create(&path, "", None).unwrap();
 
         let src = "// @name: TestScript\n// @description: desc\n";
         let (script, _) = ws.create_user_script(src).unwrap();
@@ -5728,7 +5925,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_undo_redo_create_note_cycle() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.krillnotes");
-        let mut ws = Workspace::create(&path, "").unwrap();
+        let mut ws = Workspace::create(&path, "", None).unwrap();
         let root_id = ws.create_note_root("TextNote").unwrap();
         ws.undo_stack.clear();
 
@@ -5753,7 +5950,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_undo_delete_note_full_cycle() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.krillnotes");
-        let mut ws = Workspace::create(&path, "").unwrap();
+        let mut ws = Workspace::create(&path, "", None).unwrap();
         let root_id = ws.create_note_root("TextNote").unwrap();
         let child_id = ws.create_note(&root_id, AddPosition::AsChild, "TextNote").unwrap();
         ws.undo_stack.clear();
@@ -5769,7 +5966,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_tree_action_collapses_to_one_undo_entry() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.krillnotes");
-        let mut ws = Workspace::create(&path, "").unwrap();
+        let mut ws = Workspace::create(&path, "", None).unwrap();
         let root_id = ws.create_note_root("TextNote").unwrap();
         ws.undo_stack.clear();
 
@@ -5787,11 +5984,11 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_undo_limit_persists() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.krillnotes");
-        let mut ws = Workspace::create(&path, "").unwrap();
+        let mut ws = Workspace::create(&path, "", None).unwrap();
         ws.set_undo_limit(10).unwrap();
         drop(ws);
 
-        let ws2 = Workspace::open(&path, "").unwrap();
+        let ws2 = Workspace::open(&path, "", None).unwrap();
         assert_eq!(ws2.undo_limit, 10);
     }
 
@@ -5799,7 +5996,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_undo_limit_clamp_and_trim() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.krillnotes");
-        let mut ws = Workspace::create(&path, "").unwrap();
+        let mut ws = Workspace::create(&path, "", None).unwrap();
 
         ws.set_undo_limit(0).unwrap();
         assert_eq!(ws.get_undo_limit(), 1);
@@ -5826,7 +6023,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
         // the update.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.krillnotes");
-        let mut ws = Workspace::create(&path, "").unwrap();
+        let mut ws = Workspace::create(&path, "", None).unwrap();
 
         let src_v1 = "// @name: CycleScript\n// @description: v1\nlet x = 1;";
         let (script, _) = ws.create_user_script(src_v1).unwrap();
@@ -5858,7 +6055,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
         // the script with its real content on redo, not an empty placeholder.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.krillnotes");
-        let mut ws = Workspace::create(&path, "").unwrap();
+        let mut ws = Workspace::create(&path, "", None).unwrap();
 
         let src = "// @name: RedoScript\n// @description: test\nlet y = 42;";
         let (script, _) = ws.create_user_script(src).unwrap();
@@ -5884,7 +6081,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_write_info_json_creates_file() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("notes.db");
-        let ws = Workspace::create(&db_path, "").unwrap();
+        let ws = Workspace::create(&db_path, "", None).unwrap();
         ws.write_info_json().unwrap();
 
         let info_path = dir.path().join("info.json");
@@ -5901,7 +6098,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_write_info_json_counts_notes() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("notes.db");
-        let mut ws = Workspace::create(&db_path, "").unwrap();
+        let mut ws = Workspace::create(&db_path, "", None).unwrap();
 
         let root = ws.list_all_notes().unwrap()[0].clone();
         ws.create_note(&root.id, AddPosition::AsChild, "TextNote").unwrap();
@@ -5917,7 +6114,7 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_info_json_written_on_create() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("notes.db");
-        Workspace::create(&db_path, "").unwrap();
+        Workspace::create(&db_path, "", None).unwrap();
         assert!(dir.path().join("info.json").exists(), "info.json must exist after create");
     }
 
@@ -5925,9 +6122,67 @@ add_tree_action("Create Then Fail", ["TaErrFolder"], |folder| {
     fn test_info_json_written_on_open() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("notes.db");
-        Workspace::create(&db_path, "").unwrap();
+        Workspace::create(&db_path, "", None).unwrap();
         std::fs::remove_file(dir.path().join("info.json")).unwrap(); // remove it
-        Workspace::open(&db_path, "").unwrap();
+        Workspace::open(&db_path, "", None).unwrap();
         assert!(dir.path().join("info.json").exists(), "info.json must be rewritten on open");
+    }
+
+    // ── HLC-specific tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_hlc_counter_increments_for_rapid_ops() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("hlc.krillnotes");
+        let mut ws = Workspace::create(&path, "", None).unwrap();
+
+        // Create two notes in rapid succession.
+        ws.create_note_root("TextNote").unwrap();
+        ws.create_note_root("TextNote").unwrap();
+
+        let ops = ws.list_operations(None, None, None).unwrap();
+        assert!(ops.len() >= 2, "at least two operations must be logged");
+
+        // Every logged timestamp must be a valid non-zero wall clock value.
+        for op in &ops {
+            assert!(op.timestamp_wall_ms > 0, "wall_ms must be non-zero");
+        }
+
+        // All operation IDs must be unique — HLC must not produce duplicate entries.
+        let unique_ids: std::collections::HashSet<&str> =
+            ops.iter().map(|o| o.operation_id.as_str()).collect();
+        assert_eq!(unique_ids.len(), ops.len(), "all operation_ids must be unique");
+    }
+
+    #[test]
+    fn test_set_tags_op_logged() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tags_log.krillnotes");
+        let mut ws = Workspace::create(&path, "", None).unwrap();
+        let root = ws.list_all_notes().unwrap()[0].clone();
+
+        ws.update_note_tags(&root.id, vec!["crdt".into(), "hlc".into()]).unwrap();
+
+        let ops = ws.list_operations(None, None, None).unwrap();
+        let has_set_tags = ops.iter().any(|o| o.operation_type == "SetTags");
+        assert!(has_set_tags, "SetTags operation must appear in the log after update_note_tags");
+    }
+
+    #[test]
+    fn test_update_note_op_logged() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("update_note_log.krillnotes");
+        let mut ws = Workspace::create(&path, "", None).unwrap();
+        let root = ws.list_all_notes().unwrap()[0].clone();
+
+        ws.update_note_title(&root.id, "HLC Title".to_string()).unwrap();
+
+        // update_note_title logs an UpdateNote operation (not UpdateField).
+        let ops = ws.list_operations(None, None, None).unwrap();
+        let has_title_update = ops.iter().any(|o| o.operation_type == "UpdateNote");
+        assert!(
+            has_title_update,
+            "UpdateNote operation must appear in the log after update_note_title"
+        );
     }
 }

--- a/krillnotes-core/src/lib.rs
+++ b/krillnotes-core/src/lib.rs
@@ -29,9 +29,14 @@ pub use core::{
     operation::Operation,
     operation_log::{OperationLog, OperationSummary, PurgeStrategy},
     scripting::{FieldDefinition, HookRegistry, QueryContext, Schema, ScriptError, ScriptRegistry, StarterScript},
+    hlc::{HlcClock, HlcTimestamp},
     identity::{IdentityFile, IdentityManager, IdentitySettings, IdentityRef, WorkspaceBinding, UnlockedIdentity, SwarmIdFile},
     storage::Storage,
     undo::{RetractInverse, UndoResult},
     user_script::UserScript,
     workspace::{AddPosition, NoteSearchResult, Workspace},
 };
+
+// Re-export SigningKey so consumers don't need a direct ed25519-dalek dependency.
+#[doc(inline)]
+pub use ed25519_dalek::SigningKey as Ed25519SigningKey;

--- a/krillnotes-desktop/src-tauri/src/lib.rs
+++ b/krillnotes-desktop/src-tauri/src/lib.rs
@@ -24,7 +24,7 @@ pub use krillnotes_core::*;
 use uuid::Uuid;
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Manager, State};
@@ -416,11 +416,19 @@ async fn create_workspace(
                 base64::engine::general_purpose::STANDARD.encode(&bytes)
             };
 
+            // Get the signing key from the unlocked identity before creating the workspace.
+            let signing_key = {
+                let identities = state.unlocked_identities.lock().expect("Mutex poisoned");
+                let unlocked = identities.get(&uuid)
+                    .ok_or_else(|| "Identity is not unlocked".to_string())?;
+                Ed25519SigningKey::from_bytes(&unlocked.signing_key.to_bytes())
+            };
+
             let label = generate_unique_label(&state, &folder);
             std::fs::create_dir_all(&folder)
                 .map_err(|e| format!("Failed to create workspace directory: {e}"))?;
             let db_path = folder.join("notes.db");
-            let workspace = Workspace::create(&db_path, &password)
+            let workspace = Workspace::create(&db_path, &password, Some(signing_key))
                 .map_err(|e| format!("Failed to create: {e}"))?;
 
             // Read the workspace_id from the newly created workspace
@@ -519,7 +527,8 @@ async fn open_workspace(
                     .map_err(|e| format!("Failed to decrypt DB password: {e}"))?
             };
 
-            let workspace = Workspace::open(&db_path, &db_password)
+            let signing_key = Ed25519SigningKey::from_bytes(&seed);
+            let workspace = Workspace::open(&db_path, &db_password, Some(signing_key))
                 .map_err(|e| match e {
                     KrillnotesError::WrongPassword => "WRONG_PASSWORD".to_string(),
                     KrillnotesError::UnencryptedWorkspace => "UNENCRYPTED_WORKSPACE".to_string(),
@@ -832,7 +841,7 @@ fn update_note(
     state: State<'_, AppState>,
     note_id: String,
     title: String,
-    fields: HashMap<String, FieldValue>,
+    fields: BTreeMap<String, FieldValue>,
 ) -> std::result::Result<Note, String> {
     let label = window.label();
     let mut workspaces = state.workspaces.lock()
@@ -1034,7 +1043,7 @@ fn move_note(
     state: State<'_, AppState>,
     note_id: String,
     new_parent_id: Option<String>,
-    new_position: i32,
+    new_position: f64,
 ) -> std::result::Result<(), String> {
     let label = window.label();
     let mut workspaces = state.workspaces.lock()
@@ -1246,12 +1255,27 @@ fn list_operations(
     until: Option<i64>,
 ) -> std::result::Result<Vec<krillnotes_core::OperationSummary>, String> {
     let label = window.label();
-    state.workspaces.lock()
+    let mut summaries = state.workspaces.lock()
         .expect("Mutex poisoned")
         .get(label)
         .ok_or("No workspace open")?
         .list_operations(type_filter.as_deref(), since, until)
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+
+    // Resolve raw base64 public keys to identity display names where possible.
+    let identity_manager = state.identity_manager.lock().expect("Mutex poisoned");
+    for summary in &mut summaries {
+        if !summary.author_key.is_empty() {
+            if let Some(name) = identity_manager.lookup_display_name(&summary.author_key) {
+                summary.author_key = name;
+            } else {
+                // Unknown key: show first 8 chars of base64 as a compact fingerprint.
+                summary.author_key = summary.author_key.chars().take(8).collect();
+            }
+        }
+    }
+
+    Ok(summaries)
 }
 
 /// Deletes all operations from the log.
@@ -1336,6 +1360,15 @@ async fn execute_import(
         base64::engine::general_purpose::STANDARD.encode(&bytes)
     };
 
+    // Extract the signing key from the unlocked identity before opening the workspace.
+    let uuid = Uuid::parse_str(&identity_uuid).map_err(|e| e.to_string())?;
+    let import_seed = {
+        let identities = state.unlocked_identities.lock().expect("Mutex poisoned");
+        let unlocked = identities.get(&uuid)
+            .ok_or_else(|| "Identity is not unlocked".to_string())?;
+        unlocked.signing_key.to_bytes()
+    };
+
     let file = std::fs::File::open(&zip_path).map_err(|e| e.to_string())?;
     let reader = std::io::BufReader::new(file);
     import_workspace(reader, &db_path_buf, password.as_deref(), &workspace_password)
@@ -1344,11 +1377,11 @@ async fn execute_import(
     // Ensure the attachments directory exists after import
     let _ = std::fs::create_dir_all(folder.join("attachments"));
 
-    let workspace = Workspace::open(&db_path_buf, &workspace_password)
+    let import_signing_key = Ed25519SigningKey::from_bytes(&import_seed);
+    let workspace = Workspace::open(&db_path_buf, &workspace_password, Some(import_signing_key))
         .map_err(|e| e.to_string())?;
 
     // Bind the imported workspace to the chosen identity so it can be opened later.
-    let uuid = Uuid::parse_str(&identity_uuid).map_err(|e| e.to_string())?;
     let workspace_uuid = workspace.workspace_id().to_string();
     {
         let identities = state.unlocked_identities.lock().expect("Mutex poisoned");
@@ -2129,8 +2162,8 @@ fn duplicate_workspace(
         base64::engine::general_purpose::STANDARD.encode(&bytes)
     };
 
-    // Open the source workspace and export to a temp file
-    let workspace = Workspace::open(&source_db, &source_password)
+    // Open the source workspace and export to a temp file (no signing key needed for export)
+    let workspace = Workspace::open(&source_db, &source_password, None)
         .map_err(|e| e.to_string())?;
 
     let mut tmp_file = tempfile::tempfile()
@@ -2150,8 +2183,8 @@ fn duplicate_workspace(
     import_workspace(tmp_file, &dest_db, Some(&source_password), &new_password)
         .map_err(|e| e.to_string())?;
 
-    // Write info.json for the new workspace so we can read its UUID
-    let new_ws = Workspace::open(&dest_db, &new_password)
+    // Write info.json for the new workspace so we can read its UUID (no signing key needed here)
+    let new_ws = Workspace::open(&dest_db, &new_password, None)
         .map_err(|e| format!("Failed to open new workspace: {e}"))?;
     let _ = new_ws.write_info_json();
     let new_ws_uuid = new_ws.workspace_id().to_string();

--- a/krillnotes-desktop/src-tauri/src/menu.rs
+++ b/krillnotes-desktop/src-tauri/src/menu.rs
@@ -109,7 +109,7 @@ fn build_tools_menu<R: Runtime>(app: &AppHandle<R>, strings: &Value) -> Result<T
 
     Ok(ToolsMenuResult {
         submenu,
-        workspace_items: vec![manage_scripts],
+        workspace_items: vec![manage_scripts, operations_log],
     })
 }
 

--- a/krillnotes-desktop/src/components/OperationsLogDialog.tsx
+++ b/krillnotes-desktop/src/components/OperationsLogDialog.tsx
@@ -25,8 +25,8 @@ const OPERATION_TYPES = [
   'DeleteUserScript',
 ] as const;
 
-function formatTimestamp(unix: number): string {
-  const date = new Date(unix * 1000);
+function formatTimestamp(wallMs: number): string {
+  const date = new Date(wallMs);
   return date.toLocaleString();
 }
 
@@ -42,10 +42,10 @@ function OperationsLogDialog({ isOpen, onClose }: OperationsLogDialogProps) {
   const loadOperations = useCallback(async () => {
     try {
       const since = sinceDate
-        ? Math.floor(new Date(sinceDate + 'T00:00:00').getTime() / 1000)
+        ? new Date(sinceDate + 'T00:00:00').getTime()
         : undefined;
       const until = untilDate
-        ? Math.floor(new Date(untilDate + 'T23:59:59').getTime() / 1000)
+        ? new Date(untilDate + 'T23:59:59').getTime()
         : undefined;
 
       const result = await invoke<OperationSummary[]>('list_operations', {
@@ -154,6 +154,7 @@ function OperationsLogDialog({ isOpen, onClose }: OperationsLogDialogProps) {
                 <tr>
                   <th className="text-left px-4 py-2 font-medium text-muted-foreground">{t('log.dateTime')}</th>
                   <th className="text-left px-4 py-2 font-medium text-muted-foreground">{t('log.target')}</th>
+                  <th className="text-left px-4 py-2 font-medium text-muted-foreground">{t('log.author')}</th>
                   <th className="text-right px-4 py-2 font-medium text-muted-foreground">{t('log.type')}</th>
                 </tr>
               </thead>
@@ -161,10 +162,15 @@ function OperationsLogDialog({ isOpen, onClose }: OperationsLogDialogProps) {
                 {operations.map((op) => (
                   <tr key={op.operationId} className="border-b border-border/50 hover:bg-muted/20">
                     <td className="px-4 py-2 text-muted-foreground whitespace-nowrap">
-                      {formatTimestamp(op.timestamp)}
+                      {formatTimestamp(op.timestampWallMs)}
                     </td>
-                    <td className="px-4 py-2 truncate max-w-[250px]" title={op.targetName}>
+                    <td className="px-4 py-2 truncate max-w-[200px]" title={op.targetName}>
                       {op.targetName || <span className="text-muted-foreground italic">&mdash;</span>}
+                    </td>
+                    <td className="px-4 py-2 whitespace-nowrap">
+                      <span className="text-xs font-mono text-muted-foreground">
+                        {op.authorKey || '—'}
+                      </span>
                     </td>
                     <td className="px-4 py-2 text-right">
                       <span className="inline-block bg-muted text-muted-foreground rounded px-2 py-0.5 text-xs font-mono">

--- a/krillnotes-desktop/src/i18n/locales/de.json
+++ b/krillnotes-desktop/src/i18n/locales/de.json
@@ -248,6 +248,7 @@
     "noOperations": "Keine Vorgänge gefunden.",
     "dateTime": "Datum & Uhrzeit",
     "target": "Ziel",
+    "author": "Autor",
     "type": "Typ",
     "count_one": "{{count}} Vorgang",
     "count_other": "{{count}} Vorgänge",

--- a/krillnotes-desktop/src/i18n/locales/en.json
+++ b/krillnotes-desktop/src/i18n/locales/en.json
@@ -248,6 +248,7 @@
     "noOperations": "No operations found.",
     "dateTime": "Date & Time",
     "target": "Target",
+    "author": "Author",
     "type": "Type",
     "count_one": "{{count}} operation",
     "count_other": "{{count}} operations",

--- a/krillnotes-desktop/src/i18n/locales/es.json
+++ b/krillnotes-desktop/src/i18n/locales/es.json
@@ -248,6 +248,7 @@
     "noOperations": "No se encontraron operaciones.",
     "dateTime": "Fecha y hora",
     "target": "Destino",
+    "author": "Autor",
     "type": "Tipo",
     "count_one": "{{count}} operación",
     "count_other": "{{count}} operaciones",

--- a/krillnotes-desktop/src/i18n/locales/fr.json
+++ b/krillnotes-desktop/src/i18n/locales/fr.json
@@ -248,6 +248,7 @@
     "noOperations": "Aucune opération trouvée.",
     "dateTime": "Date et heure",
     "target": "Cible",
+    "author": "Auteur",
     "type": "Type",
     "count_one": "{{count}} opération",
     "count_other": "{{count}} opérations",

--- a/krillnotes-desktop/src/i18n/locales/ja.json
+++ b/krillnotes-desktop/src/i18n/locales/ja.json
@@ -247,6 +247,7 @@
     "noOperations": "操作が見つかりませんでした。",
     "dateTime": "日時",
     "target": "対象",
+    "author": "作成者",
     "type": "種類",
     "count": "{{count}} 件",
     "deleteAll": "すべての操作を削除しますか？",

--- a/krillnotes-desktop/src/i18n/locales/ko.json
+++ b/krillnotes-desktop/src/i18n/locales/ko.json
@@ -247,6 +247,7 @@
     "noOperations": "작업을 찾을 수 없습니다.",
     "dateTime": "날짜 및 시간",
     "target": "대상",
+    "author": "작성자",
     "type": "유형",
     "count": "{{count}} 건",
     "deleteAll": "모든 작업을 삭제하시겠습니까?",

--- a/krillnotes-desktop/src/i18n/locales/zh.json
+++ b/krillnotes-desktop/src/i18n/locales/zh.json
@@ -247,6 +247,7 @@
     "noOperations": "未找到操作。",
     "dateTime": "日期和时间",
     "target": "目标",
+    "author": "作者",
     "type": "类型",
     "count": "{{count}} 条",
     "deleteAll": "删除所有操作？",

--- a/krillnotes-desktop/src/types.ts
+++ b/krillnotes-desktop/src/types.ts
@@ -111,10 +111,11 @@ export interface DropIndicator {
 
 export interface OperationSummary {
   operationId: string;
-  timestamp: number;
+  timestampWallMs: number;  // milliseconds
   deviceId: string;
   operationType: string;
   targetName: string;
+  authorKey: string;        // first 8 chars of base64 key, or ""
 }
 
 export interface AppSettings {


### PR DESCRIPTION
…ne 2) (#74)

* chore: add blake3 dependency for HLC node_id derivation

* feat: implement HlcTimestamp and HlcClock in hlc.rs

Adds krillnotes-core/src/core/hlc.rs with:
- HlcTimestamp (wall_ms, counter, node_id) with Ord + compact JSON array serde
- node_id_from_device() using BLAKE3 hash of device UUID
- HlcClock with now(), observe(), load_from_db(), save_to_db()
- 7 unit tests (all passing)

Also registers the module via pub mod hlc in core/mod.rs.

* fix: counter overflow protection and i64 safety comment in hlc.rs

- Replace bare `+ 1` counter increments in now() and observe() with saturating_add(1) via a new HlcClock::saturating_increment() helper. Prevents debug-build panics and release-build silent wrap at u32::MAX.
- Update load_from_db signature to accept node_id: u32 so the no-row fallback clock carries the correct node identity instead of always using 0.
- Add explanatory comments on i64 cast in load_from_db and save_to_db (SQLite INTEGER is i64; wall_ms won't overflow until year ~292M).

* feat: re-export HlcTimestamp and HlcClock from krillnotes-core lib.rs

* feat: DB migration — HLC timestamp columns, hlc_state table, position REAL

- Add hlc_state table (single-row, id=1 CHECK constraint)
- Recreate operations table replacing timestamp INTEGER with timestamp_wall_ms / timestamp_counter / timestamp_node_id columns
- Recreate notes table changing position INTEGER → REAL (for future fractional CRDT ordering)
- Seed hlc_state from max existing timestamp_wall_ms on migration
- Update operation_log.rs: INSERT uses new HLC columns; purge and list queries reference timestamp_wall_ms; LocalOnly purge no longer uses AUTOINCREMENT id
- Update workspace.rs NoteRow to read position as f64 (REAL column)
- Update schema.sql to reflect post-migration schema

* feat: update Operation enum with HlcTimestamp, UpdateNote, SetTags, signing

- Replace `timestamp: i64` with `timestamp: HlcTimestamp` across all Operation variants
- Replace `created_by/modified_by/deleted_by/moved_by: i64` with `String` (base64 public key placeholder) in all mutating variants
- Add `signature: String` field to all mutating variants (Ed25519 sig)
- Change `position: i32` to `f64` on CreateNote and MoveNote
- Add two new variants: UpdateNote and SetTags
- Add `author_key()` accessor method
- Add `sign()` and `verify()` methods using ed25519-dalek
- Add private helpers: set_author_key, set_signature, get_signature
- Add `HlcTimestamp::from_unix_secs()` compatibility helper in hlc.rs
- Update operation_log.rs: fix log() to use ts.wall_ms/counter/node_id, add UpdateNote/SetTags to operation_type_name(), update tests
- Update workspace.rs: add HlcTimestamp import, fix all Operation construction sites to use HlcTimestamp::from_unix_secs() and String placeholders for author keys (proper wiring in later tasks)
- All 361 unit tests pass

* fix: use BTreeMap for CreateNote.fields to ensure deterministic signing payload

HashMap serialization order is non-deterministic across processes, which would cause Ed25519 sign/verify to fail intermittently for CreateNote operations with more than one field.

Changed `CreateNote.fields`, `Note.fields`, `ActionCreate.fields`, and `ActionUpdate.fields` from HashMap to BTreeMap throughout krillnotes-core. All functions that construct or accept FieldValue maps updated accordingly.

Added `test_create_note_sign_and_verify_multi_field` to operation.rs to explicitly verify that a CreateNote with three fields signs and verifies correctly.

* feat: update operation_log.rs for HLC columns, OperationSummary fields

- OperationSummary: rename `timestamp: i64` → `timestamp_wall_ms: u64`
- OperationSummary: add `author_key: String` (first 8 chars of base64 pubkey)
- list(): ORDER BY extended with timestamp_node_id DESC, operation_id DESC
- list(): row mapping updated to populate new struct fields
- Add extract_author_key() helper (reads created_by/modified_by/deleted_by/moved_by from JSON)
- WithSync purge already used timestamp_wall_ms ms cutoff (no change needed)
- All 362 tests pass

* feat: add HlcClock and signing_key to Workspace, wire into all mutation methods

- Add `hlc: HlcClock` and `signing_key: Option<ed25519_dalek::SigningKey>` fields to Workspace struct
- `Workspace::create()` and `Workspace::open()` now accept a `signing_key` parameter
- `create()` seeds a fresh HlcClock; `open()` loads HLC state from the `hlc_state` table
- Add `advance_hlc()`, `save_hlc()`, and `sign_op_with()` static helpers to avoid borrow-checker conflicts with active transactions
- Wire HLC timestamps and optional signing into all 13 mutation methods: create_note, create_note_root, deep_copy_note, update_note, update_note_title, update_note_tags (now emits SetTags), move_note, delete_note_recursive, delete_note_promote, create_user_script, update_user_script, delete_user_script, toggle_user_script, reorder_user_script, and undo/redo RetractOperation logging
- update_note_tags now emits a SetTags operation (was previously unlogged)
- All 362 core tests pass

* feat: f64 positions in RetractInverse for undo consistency

* fix: move_note takes f64 position per spec, remove bridging i32 cast

Change pub fn move_note signature from new_position: i32 to f64, matching spec §6.3 (MoveNote.new_position: f64). Remove the as i32 bridging cast in apply_retract_inverse_internal and the as f64 cast when building the Operation::MoveNote variant. Update all call sites including the Tauri command and test helpers.

* fix: remove remaining position as i32 cast in workspace.rs

Change Note.position from i32 to f64 to match Operation.position (f64) and the DB schema (REAL). Remove all bridging casts: `position as i32` in note_from_row_tuple and five `note.position as f64` casts when building Operation/RetractInverse structs. Update integer literals in AddPosition arm and Note constructors throughout workspace.rs, note.rs, scripting/mod.rs, and scripting/display_helpers.rs. Fix test assertions to use f64 literals (0.0, 1.0, etc.) and Vec<f64> with sort_by.

All 362 tests pass.

* feat: pass signing key from unlocked identity to Workspace::open/create

- Re-export ed25519_dalek::SigningKey as Ed25519SigningKey from krillnotes-core so downstream crates don't need a direct ed25519-dalek dependency
- open_workspace: reconstruct SigningKey from seed bytes and pass to Workspace::open
- create_workspace: extract SigningKey from unlocked identity before Workspace::create
- execute_import: extract seed/SigningKey before Workspace::open so binding still works
- duplicate_workspace: pass None for temporary workspaces used only for export/import
- Fix update_note Tauri command: fields parameter changed from HashMap to BTreeMap to match the updated Workspace::update_note signature

* feat: update OperationsLogDialog for HLC timestampWallMs and authorKey

- OperationSummary type: timestamp → timestampWallMs (ms), add authorKey
- formatTimestamp: remove * 1000 (already ms)
- since/until filters: use getTime() directly (ms, not seconds)
- Add Author column showing first 8 chars of authorKey (or "—")

* test: add HLC-specific tests for counter ordering, SetTags/UpdateNote logging, sign/verify

- test_hlc_counter_increments_for_rapid_ops: verifies wall_ms > 0 and all operation IDs are unique after two rapid CreateNote calls
- test_set_tags_op_logged: asserts SetTags appears in the log after update_note_tags
- test_update_note_op_logged: asserts UpdateField appears in the log after update_note_title (update_note_title logs UpdateField with field="title")
- sign/verify round-trip already covered by existing tests in operation.rs (test_sign_and_verify, test_create_note_sign_and_verify_multi_field)

* fix: update_note_title emits UpdateNote operation per spec

All three call-sites that constructed Operation::UpdateField with field="title" (update_note_title, apply_updates batch, and update_note) now emit Operation::UpdateNote instead, matching the spec requirement for separate LWW conflict resolution on note titles.

The test test_update_note_op_logged is updated to assert operation_type == "UpdateNote".

* docs: TypeScript clean, DEVELOPER.md updated for HLC/signed operations

- TypeScript type check passes with zero errors
- Add hlc.rs to repository layout listing
- Update Operation enum example: HlcTimestamp timestamps, f64 positions, signature field, SetTags and UpdateNote variants, retracted_ids Vec
- Add HlcTimestamp/HlcClock entry in Key Files at a Glance table
- Update "each operation carries" description to mention HLC + Ed25519 signature
- Update database schema description: 7 tables including hlc_state, operations has timestamp_wall_ms/counter/node_id columns, notes.position is now REAL (f64)
- Update Tree Hierarchy section: position is now f64 (mid-point strategy)
- Add roadmap entry for milestone 12: HLC + signed operations

* fix: add missing log.author i18n key to all 7 locale files

* fix: add operations_log to workspace_items so it enables when workspace opens

* feat: resolve author public key to identity display name in operations log