### PR TITLE
refactor: rename allowed_*_types → allowed_*_schemas and target_type → target_schema

### DIFF
--- a/SCRIPTING.md
+++ b/SCRIPTING.md
@@ -107,8 +107,8 @@ schema("TypeName", #{
     title_can_view:         true,          // default: true
     title_can_edit:         true,          // default: true
     children_sort:          "asc",         // "asc" | "desc" | "none" (default)
-    allowed_parent_types:   ["Folder"],    // default: [] (any parent allowed)
-    allowed_children_types: ["Item"],      // default: [] (any child allowed)
+    allowed_parent_schemas:   ["Folder"],    // default: [] (any parent allowed)
+    allowed_children_schemas: ["Item"],      // default: [] (any child allowed)
 
     // --- required ---
     fields: [
@@ -178,7 +178,7 @@ but users cannot change it directly.
 | `"email"` | String | Email input with mailto link in view mode |
 | `"select"` | String | Dropdown; requires `options: [...]` |
 | `"rating"` | Float | Star rating; requires `max: N` (e.g. `max: 5`) |
-| `"note_link"` | String (UUID) or `null` | Link to another note; optional `target_type` restricts the picker to notes of that schema type |
+| `"note_link"` | String (UUID) or `null` | Link to another note; optional `target_schema` restricts the picker to notes of that schema type |
 | `"file"` | String (UUID) or `null` | Attachment reference; optional `allowed_types` restricts the file picker to specific MIME types. In view mode images render as a thumbnail; other files show a paperclip icon and filename. |
 
 ### Reading field values in hooks
@@ -215,7 +215,7 @@ if linked_id != () {
 
 | Option | Type | Description |
 |---|---|---|
-| `target_type` | String (optional) | If set, the note-picker in edit mode only shows notes of this schema type. |
+| `target_schema` | String (optional) | If set, the note-picker in edit mode only shows notes of this schema type. |
 
 ### `file` field options
 
@@ -260,23 +260,23 @@ Hides the title entirely in view mode. Rarely needed.
 Automatically sorts child notes alphabetically by title when displayed in the tree.
 Default is `"none"` (manual/insertion order).
 
-### `allowed_parent_types: [...]`
+### `allowed_parent_schemas: [...]`
 
 Restricts which note types this type may be placed under. An empty array means no restriction.
 
 ```rhai
-allowed_parent_types: ["ContactsFolder"],
+allowed_parent_schemas: ["ContactsFolder"],
 ```
 
-### `allowed_children_types: [...]`
+### `allowed_children_schemas: [...]`
 
 Restricts which note types may be placed inside this type.
 
 ```rhai
-allowed_children_types: ["Contact"],
+allowed_children_schemas: ["Contact"],
 ```
 
-> **Validation order:** `allowed_parent_types` and `allowed_children_types` are always checked
+> **Validation order:** `allowed_parent_schemas` and `allowed_children_schemas` are always checked
 > **before** any hook runs. If validation fails the operation is aborted and no hook fires.
 
 ### `field_groups: [...]`
@@ -616,7 +616,7 @@ Both `parent_note` and `child_note` are available by ID.
 | Note moved under a new parent (drag-and-drop) | Yes |
 | Note created at root level (no parent) | No |
 
-`allowed_parent_types` and `allowed_children_types` checks always run **before** the hook.
+`allowed_parent_schemas` and `allowed_children_schemas` checks always run **before** the hook.
 If either check fails, the operation is aborted and the hook never runs.
 
 ### Example — child count in parent title
@@ -1191,14 +1191,14 @@ schema("Contact", #{
 ```rhai
 schema("ProjectFolder", #{
     version: 1,
-    allowed_children_types: ["Project"],
+    allowed_children_schemas: ["Project"],
     fields: [],
     on_save: |note| { commit(); }
 });
 
 schema("Project", #{
     version: 1,
-    allowed_parent_types: ["ProjectFolder"],
+    allowed_parent_schemas: ["ProjectFolder"],
     fields: [ /* … */ ],
     on_save: |note| { commit(); }
 });
@@ -1308,7 +1308,7 @@ Two files: the schema definition and a presentation script for the folder view.
 schema("ContactsFolder", #{
     version: 1,
     children_sort: "asc",
-    allowed_children_types: ["Contact"],
+    allowed_children_schemas: ["Contact"],
     fields: [
         #{ name: "notes", type: "textarea", required: false },
     ],
@@ -1318,7 +1318,7 @@ schema("ContactsFolder", #{
 schema("Contact", #{
     version: 1,
     title_can_edit: false,
-    allowed_parent_types: ["ContactsFolder"],
+    allowed_parent_schemas: ["ContactsFolder"],
     fields: [
         #{ name: "first_name", type: "text",    required: true  },
         #{ name: "last_name",  type: "text",    required: true  },
@@ -1375,7 +1375,7 @@ a hook. The `Kasten` folder shows recent notes and a live child count in hover.
 schema("Zettel", #{
     version: 1,
     title_can_edit: false,
-    allowed_parent_types: ["Kasten"],
+    allowed_parent_schemas: ["Kasten"],
     fields: [
         #{ name: "body", type: "textarea", required: false, show_on_hover: true },
     ],
@@ -1396,7 +1396,7 @@ schema("Zettel", #{
 
 schema("Kasten", #{
     version: 1,
-    allowed_children_types: ["Zettel"],
+    allowed_children_schemas: ["Zettel"],
     fields: [],
     on_save: |note| { commit(); }
 });

--- a/krillnotes-core/src/core/scripting/display_helpers.rs
+++ b/krillnotes-core/src/core/scripting/display_helpers.rs
@@ -881,11 +881,11 @@ mod tests {
             fields: vec![FieldDefinition {
                 name: "notes".into(), field_type: "textarea".into(),
                 required: false, can_view: true, can_edit: true,
-                options: vec![], max: 0, target_type: None, show_on_hover: false, allowed_types: vec![], validate: None,
+                options: vec![], max: 0, target_schema: None, show_on_hover: false, allowed_types: vec![], validate: None,
             }],
             title_can_view: true, title_can_edit: true,
             children_sort: "none".into(),
-            allowed_parent_types: vec![], allowed_children_types: vec![],
+            allowed_parent_schemas: vec![], allowed_children_schemas: vec![],
             allow_attachments: false,
             attachment_types: vec![], field_groups: vec![], ast: None, version: 1, migrations: std::collections::BTreeMap::new(),
         };
@@ -913,11 +913,11 @@ mod tests {
             fields: vec![FieldDefinition {
                 name: "name".into(), field_type: "text".into(),
                 required: false, can_view: true, can_edit: true,
-                options: vec![], max: 0, target_type: None, show_on_hover: false, allowed_types: vec![], validate: None,
+                options: vec![], max: 0, target_schema: None, show_on_hover: false, allowed_types: vec![], validate: None,
             }],
             title_can_view: true, title_can_edit: true,
             children_sort: "none".into(),
-            allowed_parent_types: vec![], allowed_children_types: vec![],
+            allowed_parent_schemas: vec![], allowed_children_schemas: vec![],
             allow_attachments: false,
             attachment_types: vec![], field_groups: vec![], ast: None, version: 1, migrations: std::collections::BTreeMap::new(),
         };
@@ -945,11 +945,11 @@ mod tests {
             fields: vec![FieldDefinition {
                 name: "secret".into(), field_type: "text".into(),
                 required: false, can_view: false, can_edit: true,
-                options: vec![], max: 0, target_type: None, show_on_hover: false, allowed_types: vec![], validate: None,
+                options: vec![], max: 0, target_schema: None, show_on_hover: false, allowed_types: vec![], validate: None,
             }],
             title_can_view: true, title_can_edit: true,
             children_sort: "none".into(),
-            allowed_parent_types: vec![], allowed_children_types: vec![],
+            allowed_parent_schemas: vec![], allowed_children_schemas: vec![],
             allow_attachments: false,
             attachment_types: vec![], field_groups: vec![], ast: None, version: 1, migrations: std::collections::BTreeMap::new(),
         };
@@ -980,11 +980,11 @@ mod tests {
             fields: vec![FieldDefinition {
                 name: "body".into(), field_type: "textarea".into(),
                 required: false, can_view: true, can_edit: true,
-                options: vec![], max: 0, target_type: None, show_on_hover: false, allowed_types: vec![], validate: None,
+                options: vec![], max: 0, target_schema: None, show_on_hover: false, allowed_types: vec![], validate: None,
             }],
             title_can_view: true, title_can_edit: true,
             children_sort: "none".into(),
-            allowed_parent_types: vec![], allowed_children_types: vec![],
+            allowed_parent_schemas: vec![], allowed_children_schemas: vec![],
             allow_attachments: false,
             attachment_types: vec![], field_groups: vec![], ast: None, version: 1, migrations: std::collections::BTreeMap::new(),
         };
@@ -1039,11 +1039,11 @@ mod tests {
             fields: vec![FieldDefinition {
                 name: "known".into(), field_type: "text".into(),
                 required: false, can_view: true, can_edit: true,
-                options: vec![], max: 0, target_type: None, show_on_hover: false, allowed_types: vec![], validate: None,
+                options: vec![], max: 0, target_schema: None, show_on_hover: false, allowed_types: vec![], validate: None,
             }],
             title_can_view: true, title_can_edit: true,
             children_sort: "none".into(),
-            allowed_parent_types: vec![], allowed_children_types: vec![],
+            allowed_parent_schemas: vec![], allowed_children_schemas: vec![],
             allow_attachments: false,
             attachment_types: vec![], field_groups: vec![], ast: None, version: 1, migrations: std::collections::BTreeMap::new(),
         };
@@ -1376,11 +1376,11 @@ mod tests {
             fields: vec![FieldDefinition {
                 name: "body".into(), field_type: "textarea".into(),
                 required: false, can_view: true, can_edit: true,
-                options: vec![], max: 0, target_type: None, show_on_hover: false, allowed_types: vec![], validate: None,
+                options: vec![], max: 0, target_schema: None, show_on_hover: false, allowed_types: vec![], validate: None,
             }],
             title_can_view: true, title_can_edit: true,
             children_sort: "none".into(),
-            allowed_parent_types: vec![], allowed_children_types: vec![],
+            allowed_parent_schemas: vec![], allowed_children_schemas: vec![],
             allow_attachments: false, attachment_types: vec![], field_groups: vec![], ast: None, version: 1, migrations: std::collections::BTreeMap::new(),
         };
 

--- a/krillnotes-core/src/core/scripting/mod.rs
+++ b/krillnotes-core/src/core/scripting/mod.rs
@@ -184,7 +184,7 @@ impl ScriptRegistry {
                 let script_name = n1.lock().unwrap().clone().unwrap_or_default();
                 d1.lock().unwrap().push(DeferredBinding {
                     kind: BindingKind::View,
-                    target_type,
+                    target_schema: target_type,
                     fn_ptr,
                     ast: Arc::new(ast),
                     script_name,
@@ -214,7 +214,7 @@ impl ScriptRegistry {
                     .unwrap_or(false);
                 d2.lock().unwrap().push(DeferredBinding {
                     kind: BindingKind::View,
-                    target_type,
+                    target_schema: target_type,
                     fn_ptr,
                     ast: Arc::new(ast),
                     script_name,
@@ -241,7 +241,7 @@ impl ScriptRegistry {
                 let script_name = n3.lock().unwrap().clone().unwrap_or_default();
                 d3.lock().unwrap().push(DeferredBinding {
                     kind: BindingKind::Hover,
-                    target_type,
+                    target_schema: target_type,
                     fn_ptr,
                     ast: Arc::new(ast),
                     script_name,
@@ -271,7 +271,7 @@ impl ScriptRegistry {
                     .collect();
                 d4.lock().unwrap().push(DeferredBinding {
                     kind: BindingKind::Menu,
-                    target_type: String::new(),
+                    target_schema: String::new(),
                     fn_ptr,
                     ast: Arc::new(ast),
                     script_name,
@@ -1434,7 +1434,7 @@ mod tests {
                     can_edit: true,
                     options: vec![],
                     max: 0,
-                    target_type: None,
+                    target_schema: None,
                     show_on_hover: false,
                     allowed_types: vec![], validate: None,
                 },
@@ -1446,7 +1446,7 @@ mod tests {
                     can_edit: true,
                     options: vec![],
                     max: 0,
-                    target_type: None,
+                    target_schema: None,
                     show_on_hover: false,
                     allowed_types: vec![], validate: None,
                 },
@@ -1454,8 +1454,8 @@ mod tests {
             title_can_view: true,
             title_can_edit: true,
             children_sort: "none".to_string(),
-            allowed_parent_types: vec![],
-            allowed_children_types: vec![],
+            allowed_parent_schemas: vec![],
+            allowed_children_schemas: vec![],
             allow_attachments: false,
             attachment_types: vec![], field_groups: vec![], ast: None, version: 1, migrations: std::collections::BTreeMap::new(),
         };
@@ -1495,15 +1495,15 @@ mod tests {
                 can_edit: true,
                 options: vec![],
                 max: 0,
-                target_type: None,
+                target_schema: None,
                 show_on_hover: false,
                 allowed_types: vec![], validate: None,
             }],
             title_can_view: true,
             title_can_edit: true,
             children_sort: "none".to_string(),
-            allowed_parent_types: vec![],
-            allowed_children_types: vec![],
+            allowed_parent_schemas: vec![],
+            allowed_children_schemas: vec![],
             allow_attachments: false,
             attachment_types: vec![], field_groups: vec![], ast: None, version: 1, migrations: std::collections::BTreeMap::new(),
         };
@@ -1523,15 +1523,15 @@ mod tests {
                 can_edit: true,
                 options: vec![],
                 max: 0,
-                target_type: None,
+                target_schema: None,
                 show_on_hover: false,
                 allowed_types: vec![], validate: None,
             }],
             title_can_view: true,
             title_can_edit: true,
             children_sort: "none".to_string(),
-            allowed_parent_types: vec![],
-            allowed_children_types: vec![],
+            allowed_parent_schemas: vec![],
+            allowed_children_schemas: vec![],
             allow_attachments: false,
             attachment_types: vec![], field_groups: vec![], ast: None, version: 1, migrations: std::collections::BTreeMap::new(),
         };
@@ -3121,15 +3121,15 @@ mod tests {
                 can_edit: true,
                 options: vec![],
                 max: 0,
-                target_type: None,
+                target_schema: None,
                 show_on_hover: false,
                 allowed_types: vec![], validate: None,
             }],
             title_can_view: true,
             title_can_edit: true,
             children_sort: "none".to_string(),
-            allowed_parent_types: vec![],
-            allowed_children_types: vec![],
+            allowed_parent_schemas: vec![],
+            allowed_children_schemas: vec![],
             allow_attachments: false,
             attachment_types: vec![], field_groups: vec![], ast: None, version: 1, migrations: std::collections::BTreeMap::new(),
         };
@@ -3138,18 +3138,18 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_note_link_target_type() {
+    fn test_parse_note_link_target_schema() {
         let mut registry = ScriptRegistry::new().unwrap();
         registry.load_script(r#"
             schema("Task", #{ version: 1,
                 fields: [
-                    #{ name: "project", type: "note_link", target_type: "Project" }
+                    #{ name: "project", type: "note_link", target_schema: "Project" }
                 ]
             });
         "#, "test").unwrap();
         let fields = get_schema_fields_for_test(&registry, "Task");
         assert_eq!(fields[0].field_type, "note_link");
-        assert_eq!(fields[0].target_type, Some("Project".to_string()));
+        assert_eq!(fields[0].target_schema, Some("Project".to_string()));
     }
 
     // ── on_hover hook ────────────────────────────────────────────────────────

--- a/krillnotes-core/src/core/scripting/schema.rs
+++ b/krillnotes-core/src/core/scripting/schema.rs
@@ -44,7 +44,7 @@ pub struct MenuRegistration {
 #[derive(Debug, Clone)]
 pub struct DeferredBinding {
     pub kind: BindingKind,
-    pub target_type: String,
+    pub target_schema: String,
     pub fn_ptr: FnPtr,
     pub ast: Arc<AST>,
     pub script_name: String,
@@ -96,7 +96,7 @@ pub struct FieldDefinition {
     /// Optional schema type filter for `note_link` fields.
     /// If set, the picker only shows notes of this type. Ignored for all other field types.
     #[serde(default)]
-    pub target_type: Option<String>,
+    pub target_schema: Option<String>,
     /// When `true`, this field is included in the hover-tooltip simple-path renderer.
     /// Defaults to `false` (opt-in).
     #[serde(default)]
@@ -132,10 +132,10 @@ pub struct Schema {
     pub children_sort: String,
     /// Note types that are allowed as parents of this note type.
     /// Empty means no restriction (any parent or root is allowed).
-    pub allowed_parent_types: Vec<String>,
+    pub allowed_parent_schemas: Vec<String>,
     /// Note types that this schema allows as direct children.
     /// Empty means no restriction (any child type is allowed here).
-    pub allowed_children_types: Vec<String>,
+    pub allowed_children_schemas: Vec<String>,
     /// When `true`, the note-level attachments panel is shown for this schema.
     /// Defaults to `false` (opt-in).
     pub allow_attachments: bool,
@@ -277,8 +277,8 @@ impl Schema {
             ));
         }
 
-        let target_type: Option<String> = field_map
-            .get("target_type")
+        let target_schema: Option<String> = field_map
+            .get("target_schema")
             .and_then(|v| v.clone().try_cast::<String>());
 
         let show_on_hover = field_map
@@ -303,7 +303,7 @@ impl Schema {
             .get("validate")
             .and_then(|v| v.clone().try_cast::<rhai::FnPtr>());
 
-        Ok(FieldDefinition { name: field_name, field_type, required, can_view, can_edit, options, max, target_type, show_on_hover, allowed_types, validate })
+        Ok(FieldDefinition { name: field_name, field_type, required, can_view, can_edit, options, max, target_schema, show_on_hover, allowed_types, validate })
     }
 
     /// Parses a `Schema` from a Rhai object map produced by a `schema(...)` call.
@@ -344,29 +344,29 @@ impl Schema {
             .and_then(|v| v.clone().try_cast::<String>())
             .unwrap_or_else(|| "none".to_string());
 
-        let mut allowed_parent_types: Vec<String> = Vec::new();
+        let mut allowed_parent_schemas: Vec<String> = Vec::new();
         if let Some(arr) = def
-            .get("allowed_parent_types")
+            .get("allowed_parent_schemas")
             .and_then(|v| v.clone().try_cast::<rhai::Array>())
         {
             for item in arr {
                 let s = item.try_cast::<String>().ok_or_else(|| {
-                    KrillnotesError::Scripting("allowed_parent_types must contain only strings".into())
+                    KrillnotesError::Scripting("allowed_parent_schemas must contain only strings".into())
                 })?;
-                allowed_parent_types.push(s);
+                allowed_parent_schemas.push(s);
             }
         }
 
-        let mut allowed_children_types: Vec<String> = Vec::new();
+        let mut allowed_children_schemas: Vec<String> = Vec::new();
         if let Some(arr) = def
-            .get("allowed_children_types")
+            .get("allowed_children_schemas")
             .and_then(|v| v.clone().try_cast::<rhai::Array>())
         {
             for item in arr {
                 let s = item.try_cast::<String>().ok_or_else(|| {
-                    KrillnotesError::Scripting("allowed_children_types must contain only strings".into())
+                    KrillnotesError::Scripting("allowed_children_schemas must contain only strings".into())
                 })?;
-                allowed_children_types.push(s);
+                allowed_children_schemas.push(s);
             }
         }
 
@@ -477,7 +477,7 @@ impl Schema {
             }
         }
 
-        Ok(Schema { name: name.to_string(), fields, title_can_view, title_can_edit, children_sort, allowed_parent_types, allowed_children_types, allow_attachments, attachment_types, field_groups, ast: None, version, migrations })
+        Ok(Schema { name: name.to_string(), fields, title_can_view, title_can_edit, children_sort, allowed_parent_schemas, allowed_children_schemas, allow_attachments, attachment_types, field_groups, ast: None, version, migrations })
     }
 }
 
@@ -622,9 +622,9 @@ impl SchemaRegistry {
         for binding in bindings.drain(..) {
             match binding.kind {
                 BindingKind::View => {
-                    if schemas.contains_key(&binding.target_type) {
-                        let label = binding.label.unwrap_or_else(|| binding.target_type.clone());
-                        let slot = views.entry(binding.target_type).or_default();
+                    if schemas.contains_key(&binding.target_schema) {
+                        let label = binding.label.unwrap_or_else(|| binding.target_schema.clone());
+                        let slot = views.entry(binding.target_schema).or_default();
                         // Deduplicate: library source is prepended to each schema compilation,
                         // so register_view() in a library script fires once per schema loaded.
                         // Keep only the first registration for each (type, label) pair.
@@ -641,27 +641,27 @@ impl SchemaRegistry {
                         warnings.push(ScriptWarning {
                             script_name: binding.script_name,
                             message: format!(
-                                "register_view('{}', '{}') -- type not found",
-                                binding.target_type,
+                                "register_view('{}', '{}') -- schema not found",
+                                binding.target_schema,
                                 binding.label.unwrap_or_default()
                             ),
                         });
                     }
                 }
                 BindingKind::Hover => {
-                    if schemas.contains_key(&binding.target_type) {
+                    if schemas.contains_key(&binding.target_schema) {
                         let entry = HookEntry {
                             fn_ptr: binding.fn_ptr,
                             ast: binding.ast.as_ref().clone(),
                             script_name: binding.script_name,
                         };
-                        hovers.insert(binding.target_type, entry);
+                        hovers.insert(binding.target_schema, entry);
                     } else {
                         warnings.push(ScriptWarning {
                             script_name: binding.script_name,
                             message: format!(
-                                "register_hover('{}') -- type not found",
-                                binding.target_type
+                                "register_hover('{}') -- schema not found",
+                                binding.target_schema
                             ),
                         });
                     }

--- a/krillnotes-core/src/core/workspace.rs
+++ b/krillnotes-core/src/core/workspace.rs
@@ -1294,15 +1294,15 @@ impl Workspace {
             AddPosition::AsSibling => (selected.parent_id.clone(), selected.position + 1.0),
         };
 
-        // Validate allowed_parent_types
-        if !schema.allowed_parent_types.is_empty() {
+        // Validate allowed_parent_schemas
+        if !schema.allowed_parent_schemas.is_empty() {
             match &final_parent {
                 None => return Err(KrillnotesError::InvalidMove(format!(
                     "Note type '{}' cannot be placed at root level", note_type
                 ))),
                 Some(pid) => {
                     let parent_note = self.get_note(pid)?;
-                    if !schema.allowed_parent_types.contains(&parent_note.schema) {
+                    if !schema.allowed_parent_schemas.contains(&parent_note.schema) {
                         return Err(KrillnotesError::InvalidMove(format!(
                             "Note type '{}' cannot be placed under '{}'",
                             note_type, parent_note.schema
@@ -1312,12 +1312,12 @@ impl Workspace {
             }
         }
 
-        // Validate allowed_children_types on the parent schema
+        // Validate allowed_children_schemas on the parent schema
         if let Some(pid) = &final_parent {
             let parent_note = self.get_note(pid)?;
             let parent_schema = self.script_registry.get_schema(&parent_note.schema)?;
-            if !parent_schema.allowed_children_types.is_empty()
-                && !parent_schema.allowed_children_types.contains(&note_type.to_string())
+            if !parent_schema.allowed_children_schemas.is_empty()
+                && !parent_schema.allowed_children_schemas.contains(&note_type.to_string())
             {
                 return Err(KrillnotesError::InvalidMove(format!(
                     "Note type '{}' is not allowed as a child of '{}'",
@@ -1457,7 +1457,7 @@ impl Workspace {
     /// Returns the ID of the new root note.
     ///
     /// All notes in the subtree receive fresh UUIDs and current timestamps.
-    /// Schema constraints (`allowed_parent_types`, `allowed_children_types`) are
+    /// Schema constraints (`allowed_parent_schemas`, `allowed_children_schemas`) are
     /// validated only for the root of the copy against the paste target.
     /// Children's internal parent/child relationships are trusted and not re-validated.
     pub fn deep_copy_note(
@@ -1498,15 +1498,15 @@ impl Workspace {
             AddPosition::AsSibling => (target_note.parent_id.clone(), target_note.position + 1.0),
         };
 
-        // Validate allowed_parent_types for the root copy
-        if !root_schema.allowed_parent_types.is_empty() {
+        // Validate allowed_parent_schemas for the root copy
+        if !root_schema.allowed_parent_schemas.is_empty() {
             match &new_parent_id {
                 None => return Err(KrillnotesError::InvalidMove(format!(
                     "Note type '{}' cannot be placed at root level", root_source.schema
                 ))),
                 Some(pid) => {
                     let parent = self.get_note(pid)?;
-                    if !root_schema.allowed_parent_types.contains(&parent.schema) {
+                    if !root_schema.allowed_parent_schemas.contains(&parent.schema) {
                         return Err(KrillnotesError::InvalidMove(format!(
                             "Note type '{}' cannot be placed under '{}'",
                             root_source.schema, parent.schema
@@ -1516,12 +1516,12 @@ impl Workspace {
             }
         }
 
-        // Validate allowed_children_types on the paste parent
+        // Validate allowed_children_schemas on the paste parent
         if let Some(pid) = &new_parent_id {
             let parent = self.get_note(pid)?;
             let parent_schema = self.script_registry.get_schema(&parent.schema)?;
-            if !parent_schema.allowed_children_types.is_empty()
-                && !parent_schema.allowed_children_types.contains(&root_source.schema)
+            if !parent_schema.allowed_children_schemas.is_empty()
+                && !parent_schema.allowed_children_schemas.contains(&root_source.schema)
             {
                 return Err(KrillnotesError::InvalidMove(format!(
                     "Note type '{}' is not allowed as a child of '{}'",
@@ -1631,8 +1631,8 @@ impl Workspace {
         let now = chrono::Utc::now().timestamp();
         let schema = self.script_registry.get_schema(node_type)?;
 
-        // Validate allowed_parent_types — root notes have no parent
-        if !schema.allowed_parent_types.is_empty() {
+        // Validate allowed_parent_schemas — root notes have no parent
+        if !schema.allowed_parent_schemas.is_empty() {
             return Err(KrillnotesError::InvalidMove(format!(
                 "Note type '{}' cannot be placed at root level", node_type
             )));
@@ -1868,7 +1868,7 @@ impl Workspace {
     pub fn search_notes(
         &self,
         query: &str,
-        target_type: Option<&str>,
+        target_schema: Option<&str>,
     ) -> Result<Vec<NoteSearchResult>> {
         let query_lower = query.to_lowercase();
         if query_lower.is_empty() {
@@ -1880,7 +1880,7 @@ impl Workspace {
         let results = all_notes
             .into_iter()
             .filter(|n| {
-                if let Some(t) = target_type {
+                if let Some(t) = target_schema {
                     n.schema == t
                 } else {
                     true
@@ -2577,17 +2577,17 @@ impl Workspace {
             }
         }
 
-        // 3. Allowed-parent-types check
+        // 3. Allowed-parent-schemas check
         let note_to_move = self.get_note(note_id)?;
         let schema = self.script_registry.get_schema(&note_to_move.schema)?;
-        if !schema.allowed_parent_types.is_empty() {
+        if !schema.allowed_parent_schemas.is_empty() {
             match new_parent_id {
                 None => return Err(KrillnotesError::InvalidMove(format!(
                     "Note type '{}' cannot be placed at root level", note_to_move.schema
                 ))),
                 Some(pid) => {
                     let parent_note = self.get_note(pid)?;
-                    if !schema.allowed_parent_types.contains(&parent_note.schema) {
+                    if !schema.allowed_parent_schemas.contains(&parent_note.schema) {
                         return Err(KrillnotesError::InvalidMove(format!(
                             "Note type '{}' cannot be placed under '{}'",
                             note_to_move.schema, parent_note.schema
@@ -2597,12 +2597,12 @@ impl Workspace {
             }
         }
 
-        // 3b. Allowed-children-types check on the new parent
+        // 3b. Allowed-children-schemas check on the new parent
         if let Some(pid) = new_parent_id {
             let parent_note = self.get_note(pid)?;
             let parent_schema = self.script_registry.get_schema(&parent_note.schema)?;
-            if !parent_schema.allowed_children_types.is_empty()
-                && !parent_schema.allowed_children_types.contains(&note_to_move.schema)
+            if !parent_schema.allowed_children_schemas.is_empty()
+                && !parent_schema.allowed_children_schemas.contains(&note_to_move.schema)
             {
                 return Err(KrillnotesError::InvalidMove(format!(
                     "Note type '{}' is not allowed as a child of '{}'",
@@ -5074,7 +5074,7 @@ mod tests {
         // Contact schema is already loaded from starter scripts.
 
         let root_id = ws.list_all_notes().unwrap()[0].id.clone();
-        // Contact must be created under a ContactsFolder (allowed_parent_types constraint).
+        // Contact must be created under a ContactsFolder (allowed_parent_schemas constraint).
         let folder_id = ws
             .create_note(&root_id, AddPosition::AsChild, "ContactsFolder")
             .unwrap();
@@ -5173,7 +5173,7 @@ mod tests {
         let notes = ws.list_all_notes().unwrap();
         let root_id = notes[0].id.clone();
 
-        // Contact must be created under a ContactsFolder (allowed_parent_types constraint).
+        // Contact must be created under a ContactsFolder (allowed_parent_schemas constraint).
         let folder_id = ws
             .create_note(&root_id, AddPosition::AsChild, "ContactsFolder")
             .unwrap();

--- a/krillnotes-core/src/system_scripts/01_contact.schema.rhai
+++ b/krillnotes-core/src/system_scripts/01_contact.schema.rhai
@@ -10,7 +10,7 @@
 schema("ContactsFolder", #{
     version: 1,
     children_sort: "asc",
-    allowed_children_types: ["Contact"],
+    allowed_children_schemas: ["Contact"],
     fields: [
         #{ name: "notes", type: "textarea", required: false },
     ],
@@ -19,7 +19,7 @@ schema("ContactsFolder", #{
 schema("Contact", #{
     version: 1,
     title_can_edit: false,
-    allowed_parent_types: ["ContactsFolder"],
+    allowed_parent_schemas: ["ContactsFolder"],
     fields: [
         #{ name: "first_name",      type: "text",  required: true  },
         #{ name: "middle_name",     type: "text",  required: false },

--- a/krillnotes-desktop/src-tauri/src/lib.rs
+++ b/krillnotes-desktop/src-tauri/src/lib.rs
@@ -725,7 +725,7 @@ struct FieldDefInfo {
     can_edit: bool,
     options: Vec<String>,
     max: i64,
-    target_type: Option<String>,
+    target_schema: Option<String>,
     show_on_hover: bool,
     allowed_types: Vec<String>,
     /// `true` if a `validate` closure is registered for this field.
@@ -742,7 +742,7 @@ impl From<&FieldDefinition> for FieldDefInfo {
             can_edit: f.can_edit,
             options: f.options.clone(),
             max: f.max,
-            target_type: f.target_type.clone(),
+            target_schema: f.target_schema.clone(),
             show_on_hover: f.show_on_hover,
             allowed_types: f.allowed_types.clone(),
             has_validate: f.validate.is_some(),
@@ -769,8 +769,8 @@ struct SchemaInfo {
     title_can_view: bool,
     title_can_edit: bool,
     children_sort: String,
-    allowed_parent_types: Vec<String>,
-    allowed_children_types: Vec<String>,
+    allowed_parent_schemas: Vec<String>,
+    allowed_children_schemas: Vec<String>,
     allow_attachments: bool,
     attachment_types: Vec<String>,
     has_views: bool,
@@ -786,8 +786,8 @@ fn schema_to_info(schema: &Schema, has_views: bool, has_hover: bool) -> SchemaIn
         title_can_view: schema.title_can_view,
         title_can_edit: schema.title_can_edit,
         children_sort: schema.children_sort.clone(),
-        allowed_parent_types: schema.allowed_parent_types.clone(),
-        allowed_children_types: schema.allowed_children_types.clone(),
+        allowed_parent_schemas: schema.allowed_parent_schemas.clone(),
+        allowed_children_schemas: schema.allowed_children_schemas.clone(),
         allow_attachments: schema.allow_attachments,
         attachment_types: schema.attachment_types.clone(),
         field_groups: schema.field_groups.iter().map(|g| FieldGroupInfo {
@@ -1189,14 +1189,14 @@ fn search_notes(
     window: tauri::Window,
     state: State<'_, AppState>,
     query: String,
-    target_type: Option<String>,
+    target_schema: Option<String>,
 ) -> std::result::Result<Vec<NoteSearchResult>, String> {
     let label = window.label();
     let workspaces = state.workspaces.lock()
         .expect("Mutex poisoned");
     let workspace = workspaces.get(label)
         .ok_or("No workspace open")?;
-    workspace.search_notes(&query, target_type.as_deref())
+    workspace.search_notes(&query, target_schema.as_deref())
         .map_err(|e| e.to_string())
 }
 

--- a/krillnotes-desktop/src/components/FieldEditor.tsx
+++ b/krillnotes-desktop/src/components/FieldEditor.tsx
@@ -17,7 +17,7 @@ interface FieldEditorProps {
   required: boolean;
   options: string[];
   max: number;
-  targetType?: string;
+  targetSchema?: string;
   noteId?: string;
   fieldDef?: FieldDefinition;
   error?: string;
@@ -25,7 +25,7 @@ interface FieldEditorProps {
   onChange: (value: FieldValue) => void;
 }
 
-function FieldEditor({ fieldName, fieldType, value, required, options, max, targetType, noteId, fieldDef, error, onBlur, onChange }: FieldEditorProps) {
+function FieldEditor({ fieldName, fieldType, value, required, options, max, targetSchema, noteId, fieldDef, error, onBlur, onChange }: FieldEditorProps) {
   const { t } = useTranslation();
   const renderEditor = () => {
     if (fieldType === 'file') {
@@ -45,7 +45,7 @@ function FieldEditor({ fieldName, fieldType, value, required, options, max, targ
       return (
         <NoteLinkEditor
           value={currentId}
-          targetType={targetType}
+          targetSchema={targetSchema}
           onChange={(id) => onChange({ NoteLink: id })}
         />
       );

--- a/krillnotes-desktop/src/components/InfoPanel.tsx
+++ b/krillnotes-desktop/src/components/InfoPanel.tsx
@@ -58,8 +58,8 @@ function InfoPanel({ selectedNote, onNoteUpdated, onDeleteRequest, requestEditMo
     titleCanView: true,
     titleCanEdit: true,
     childrenSort: 'none',
-    allowedParentTypes: [],
-    allowedChildrenTypes: [],
+    allowedParentSchemas: [],
+    allowedChildrenSchemas: [],
     hasViews: false,
     hasHover: false,
     allowAttachments: false,
@@ -95,7 +95,7 @@ function InfoPanel({ selectedNote, onNoteUpdated, onDeleteRequest, requestEditMo
 
   const emptySchemaInfo: SchemaInfo = {
     fields: [], titleCanView: true, titleCanEdit: true, childrenSort: 'none',
-    allowedParentTypes: [], allowedChildrenTypes: [], hasViews: false, hasHover: false,
+    allowedParentSchemas: [], allowedChildrenSchemas: [], hasViews: false, hasHover: false,
     allowAttachments: false, attachmentTypes: [], fieldGroups: [],
   };
 
@@ -693,7 +693,7 @@ function InfoPanel({ selectedNote, onNoteUpdated, onDeleteRequest, requestEditMo
                 required={field.required}
                 options={field.options}
                 max={field.max}
-                targetType={field.targetType}
+                targetSchema={field.targetSchema}
                 noteId={selectedNote.id}
                 fieldDef={field}
                 error={fieldErrors[field.name]}
@@ -733,7 +733,7 @@ function InfoPanel({ selectedNote, onNoteUpdated, onDeleteRequest, requestEditMo
                           required={field.required}
                           options={field.options}
                           max={field.max}
-                          targetType={field.targetType}
+                          targetSchema={field.targetSchema}
                           noteId={selectedNote.id}
                           fieldDef={field}
                           error={fieldErrors[field.name]}

--- a/krillnotes-desktop/src/components/NoteLinkEditor.tsx
+++ b/krillnotes-desktop/src/components/NoteLinkEditor.tsx
@@ -11,11 +11,11 @@ import type { NoteSearchResult } from '../types';
 
 interface Props {
   value: string | null;
-  targetType?: string;
+  targetSchema?: string;
   onChange: (id: string | null) => void;
 }
 
-export function NoteLinkEditor({ value, targetType, onChange }: Props) {
+export function NoteLinkEditor({ value, targetSchema, onChange }: Props) {
   const { t } = useTranslation();
   const [displayTitle, setDisplayTitle] = useState<string>('');
   const [query, setQuery] = useState('');
@@ -54,7 +54,7 @@ export function NoteLinkEditor({ value, targetType, onChange }: Props) {
       try {
         const r = await invoke<NoteSearchResult[]>('search_notes', {
           query: q,
-          targetType: targetType ?? null,
+          targetSchema: targetSchema ?? null,
         });
         setResults(r);
       } catch {

--- a/krillnotes-desktop/src/components/TreeNode.tsx
+++ b/krillnotes-desktop/src/components/TreeNode.tsx
@@ -85,15 +85,15 @@ function TreeNode({
         prospectiveParentType = parentNote ? parentNote.schema : null;
       }
 
-      // Child constraint: dragged type's allowedParentTypes
-      const apt = schemas[draggedNote.schema]?.allowedParentTypes ?? [];
+      // Child constraint: dragged type's allowedParentSchemas
+      const apt = schemas[draggedNote.schema]?.allowedParentSchemas ?? [];
       if (apt.length > 0) {
         if (!prospectiveParentType || !apt.includes(prospectiveParentType)) return;
       }
 
-      // Parent constraint: prospective parent's allowedChildrenTypes
+      // Parent constraint: prospective parent's allowedChildrenSchemas
       if (prospectiveParentType !== null) {
-        const act = schemas[prospectiveParentType]?.allowedChildrenTypes ?? [];
+        const act = schemas[prospectiveParentType]?.allowedChildrenSchemas ?? [];
         if (act.length > 0 && !act.includes(draggedNote.schema)) return;
       }
     }
@@ -144,8 +144,8 @@ function TreeNode({
     if (draggedNote) {
       const parentNote = newParentId ? notes.find(n => n.id === newParentId) : null;
 
-      // Child constraint: dragged type's allowedParentTypes
-      const apt = schemas[draggedNote.schema]?.allowedParentTypes ?? [];
+      // Child constraint: dragged type's allowedParentSchemas
+      const apt = schemas[draggedNote.schema]?.allowedParentSchemas ?? [];
       if (apt.length > 0) {
         if (!parentNote || !apt.includes(parentNote.schema)) {
           setDraggedNoteId(null);
@@ -154,9 +154,9 @@ function TreeNode({
         }
       }
 
-      // Parent constraint: new parent's allowedChildrenTypes
+      // Parent constraint: new parent's allowedChildrenSchemas
       if (parentNote) {
-        const act = schemas[parentNote.schema]?.allowedChildrenTypes ?? [];
+        const act = schemas[parentNote.schema]?.allowedChildrenSchemas ?? [];
         if (act.length > 0 && !act.includes(draggedNote.schema)) {
           setDraggedNoteId(null);
           setDropIndicator(null);

--- a/krillnotes-desktop/src/components/TreeView.tsx
+++ b/krillnotes-desktop/src/components/TreeView.tsx
@@ -50,7 +50,7 @@ function TreeView({
     // Block if dragged note's schema restricts parent types (root has no parent)
     const draggedNote = notes.find(n => n.id === draggedNoteId);
     if (draggedNote) {
-      const apt = schemas[draggedNote.schema]?.allowedParentTypes ?? [];
+      const apt = schemas[draggedNote.schema]?.allowedParentSchemas ?? [];
       if (apt.length > 0) {
         setDraggedNoteId(null);
         setDropIndicator(null);

--- a/krillnotes-desktop/src/types.ts
+++ b/krillnotes-desktop/src/types.ts
@@ -58,7 +58,7 @@ export interface FieldDefinition {
   canEdit: boolean;
   options: string[];       // non-empty for 'select' fields
   max: number;             // non-zero for 'rating' fields
-  targetType?: string;     // only meaningful for note_link fields
+  targetSchema?: string;   // only meaningful for note_link fields
   showOnHover: boolean;
   allowedTypes: string[];  // MIME types; empty = all allowed; only meaningful for 'file' fields
   hasValidate: boolean;    // true if a validate closure is registered for this field
@@ -81,8 +81,8 @@ export interface SchemaInfo {
   titleCanView: boolean;
   titleCanEdit: boolean;
   childrenSort: 'asc' | 'desc' | 'none';
-  allowedParentTypes: string[];
-  allowedChildrenTypes: string[];
+  allowedParentSchemas: string[];
+  allowedChildrenSchemas: string[];
   hasViews: boolean;
   hasHover: boolean;
   allowAttachments: boolean;

--- a/krillnotes-desktop/src/utils/noteTypes.ts
+++ b/krillnotes-desktop/src/utils/noteTypes.ts
@@ -10,7 +10,7 @@ export type NotePosition = 'child' | 'sibling' | 'root';
 
 /**
  * Returns the note types that are valid to create at a given position.
- * - 'root'    : referenceNoteId ignored; types with no allowedParentTypes restriction
+ * - 'root'    : referenceNoteId ignored; types with no allowedParentSchemas restriction
  * - 'child'   : referenceNoteId is the intended parent
  * - 'sibling' : referenceNoteId is the intended sibling (its parent becomes the effective parent)
  */
@@ -23,7 +23,7 @@ export function getAvailableTypes(
   const allTypes = Object.keys(schemas);
 
   if (position === 'root' || referenceNoteId === null) {
-    return allTypes.filter(t => (schemas[t]?.allowedParentTypes ?? []).length === 0);
+    return allTypes.filter(t => (schemas[t]?.allowedParentSchemas ?? []).length === 0);
   }
 
   const referenceNote = notes.find(n => n.id === referenceNoteId);
@@ -39,13 +39,13 @@ export function getAvailableTypes(
   }
 
   return allTypes.filter(type => {
-    const apt = schemas[type]?.allowedParentTypes ?? [];
+    const apt = schemas[type]?.allowedParentSchemas ?? [];
     if (apt.length > 0) {
       if (effectiveParentType === null) return false;
       if (!apt.includes(effectiveParentType)) return false;
     }
     if (effectiveParentType !== null) {
-      const act = schemas[effectiveParentType]?.allowedChildrenTypes ?? [];
+      const act = schemas[effectiveParentType]?.allowedChildrenSchemas ?? [];
       if (act.length > 0 && !act.includes(type)) return false;
     }
     return true;

--- a/templates/book_collection.schema.rhai
+++ b/templates/book_collection.schema.rhai
@@ -12,7 +12,7 @@
 schema("Book", #{
     version: 1,
     title_can_edit: false,
-    allowed_parent_types: ["Library"],
+    allowed_parent_schemas: ["Library"],
     fields: [
         #{ name: "book_title",    type: "text",     required: true                   },
         #{ name: "author",        type: "text",     required: true                   },
@@ -63,6 +63,6 @@ schema("Book", #{
 
 schema("Library", #{
     version: 1,
-    allowed_children_types: ["Book"],
+    allowed_children_schemas: ["Book"],
     fields: [],
 });

--- a/templates/zettelkasten.schema.rhai
+++ b/templates/zettelkasten.schema.rhai
@@ -22,7 +22,7 @@ fn strip_markdown(s) {
 schema("Zettel", #{
     version: 1,
     title_can_edit: false,
-    allowed_parent_types: ["Kasten"],
+    allowed_parent_schemas: ["Kasten"],
     fields: [
         #{ name: "body", type: "textarea", required: false, show_on_hover: true },
     ],
@@ -46,6 +46,6 @@ schema("Zettel", #{
 
 schema("Kasten", #{
     version: 1,
-    allowed_children_types: ["Zettel"],
+    allowed_children_schemas: ["Zettel"],
     fields: [],
 });


### PR DESCRIPTION
## Summary

- `allowed_parent_types` → `allowed_parent_schemas`
- `allowed_children_types` → `allowed_children_schemas`
- `target_type` → `target_schema` (on `FieldDefinition`, `DeferredBinding`, and the `search_notes` Tauri command)

Continuation of the `node_type → schema` rename from PR #86. Updates Rust core structs and parsing, Tauri command parameters, React components and TypeScript types, Rhai system scripts, templates, and SCRIPTING.md.

## Test plan

- [ ] `cargo check -p krillnotes-core` passes
- [ ] `cargo check -p krillnotes-desktop` passes
- [ ] Existing schemas using `allowed_parent_schemas` / `allowed_children_schemas` in `.rhai` scripts work correctly
- [ ] `note_link` fields with `target_schema` correctly filter the note picker
- [ ] Tree node drag/drop respects `allowedParentSchemas` / `allowedChildrenSchemas`