### PR TITLE
feat: Sync Now as File menu item (Cmd/Ctrl+S)

### DIFF
--- a/krillnotes-desktop/src-tauri/src/lib.rs
+++ b/krillnotes-desktop/src-tauri/src/lib.rs
@@ -108,6 +108,7 @@ const MENU_MESSAGES: &[(&str, &str)] = &[
     ("file_open_swarm",       "File > Open Swarm File clicked"),
     ("file_accept_invite",    "File > Accept Invite clicked"),
     ("create_delta_swarm",    "Edit > Create delta Swarm clicked"),
+    ("file_sync_now",         "File > Sync Now clicked"),
 ];
 
 /// Translates a native [`tauri::menu::MenuEvent`] into a `"menu-action"` event

--- a/krillnotes-desktop/src-tauri/src/menu.rs
+++ b/krillnotes-desktop/src-tauri/src/menu.rs
@@ -156,9 +156,14 @@ fn build_file_menu<R: Runtime>(app: &AppHandle<R>, strings: &Value) -> Result<Fi
     )
     .build(app)?;
     let sep_sync = PredefinedMenuItem::separator(app)?;
+    let sep_sync2 = PredefinedMenuItem::separator(app)?;
+    let sync_now_item = MenuItemBuilder::with_id("file_sync_now", s(strings, "syncNow", "Sync Now"))
+        .accelerator("CmdOrCtrl+S")
+        .enabled(false)
+        .build(app)?;
 
     let builder = SubmenuBuilder::new(app, s(strings, "file", "File"))
-        .items(&[&new_item, &open_item, &identities_item, &sep1, &export_item, &import_item, &sep_sync, &open_swarm_item, &accept_invite_item, &sep2, &close_item]);
+        .items(&[&new_item, &open_item, &identities_item, &sep1, &export_item, &import_item, &sep_sync, &open_swarm_item, &accept_invite_item, &sep_sync2, &sync_now_item, &sep2, &close_item]);
 
     #[cfg(not(target_os = "macos"))]
     let builder = {
@@ -169,7 +174,7 @@ fn build_file_menu<R: Runtime>(app: &AppHandle<R>, strings: &Value) -> Result<Fi
     let submenu = builder.build()?;
     Ok(FileMenuResult {
         submenu,
-        workspace_items: vec![export_item],
+        workspace_items: vec![export_item, sync_now_item],
     })
 }
 

--- a/krillnotes-desktop/src/components/WorkspacePeersDialog.tsx
+++ b/krillnotes-desktop/src/components/WorkspacePeersDialog.tsx
@@ -8,7 +8,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import { invoke } from '@tauri-apps/api/core';
 import { useTranslation } from 'react-i18next';
-import type { PeerInfo, WorkspaceInfo, PendingPeer, ContactInfo, SyncEvent, RelayAccountInfo, ReceivedResponseInfo } from '../types';
+import type { PeerInfo, WorkspaceInfo, PendingPeer, ContactInfo, RelayAccountInfo, ReceivedResponseInfo } from '../types';
 import AddPeerFromContactsDialog from './AddPeerFromContactsDialog';
 import AddContactDialog from './AddContactDialog';
 import { InviteManagerDialog } from './InviteManagerDialog';
@@ -76,8 +76,6 @@ export default function WorkspacePeersDialog({
   const [relayAccounts, setRelayAccounts] = useState<RelayAccountInfo[]>([]);
   // Per-peer selected relay account ID (for the dropdown)
   const [pendingRelayAccount, setPendingRelayAccount] = useState<Record<string, string>>({});
-  const [syncing, setSyncing] = useState(false);
-  const [syncResult, setSyncResult] = useState<string | null>(null);
   const [resyncingPeer, setResyncingPeer] = useState<string | null>(null);
   // Share Invite Link state
   const [sharingLink, setSharingLink] = useState(false);
@@ -151,27 +149,6 @@ export default function WorkspacePeersDialog({
       await loadPeers();
     } catch (e) {
       setError(String(e));
-    }
-  };
-
-  const handleSyncNow = async () => {
-    setSyncing(true);
-    setSyncResult(null);
-    try {
-      const events = await invoke<SyncEvent[]>('poll_sync');
-      const sent = events.filter(e => e.type === 'delta_sent').length;
-      const applied = events.filter(e => e.type === 'bundle_applied').length;
-      const errors = events.filter(e => e.type === 'sync_error' || e.type === 'ingest_error');
-      if (errors.length > 0) {
-        setSyncResult(`Errors: ${errors.map(e => e.error).join(', ')}`);
-      } else {
-        setSyncResult(`Sent ${sent} bundle(s), applied ${applied} bundle(s)`);
-      }
-      await loadPeers();
-    } catch (e) {
-      setSyncResult(`Error: ${String(e)}`);
-    } finally {
-      setSyncing(false);
     }
   };
 
@@ -456,9 +433,6 @@ export default function WorkspacePeersDialog({
         </div>
 
         {/* Footer buttons */}
-        {syncResult && (
-          <p className="px-4 pb-1 text-xs text-[var(--color-muted-foreground)]">{syncResult}</p>
-        )}
         {shareSuccess && (
           shareSuccess.startsWith('http') ? (
             <div className="px-4 pb-1">
@@ -500,13 +474,6 @@ export default function WorkspacePeersDialog({
             className="whitespace-nowrap px-3 py-1.5 text-sm rounded-md border border-[var(--color-border)] hover:bg-[var(--color-secondary)]"
           >
             Create Snapshot…
-          </button>
-          <button
-            onClick={handleSyncNow}
-            disabled={syncing || peers.filter(p => p.channelType !== 'manual').length === 0}
-            className="whitespace-nowrap px-3 py-1.5 text-sm rounded-md border border-[var(--color-border)] hover:bg-[var(--color-secondary)] disabled:opacity-40"
-          >
-            {syncing ? t('peers.syncing', 'Syncing…') : t('peers.syncNow', 'Sync Now')}
           </button>
         </div>
       </div>

--- a/krillnotes-desktop/src/components/WorkspaceView.tsx
+++ b/krillnotes-desktop/src/components/WorkspaceView.tsx
@@ -28,7 +28,7 @@ import WorkspacePropertiesDialog from './WorkspacePropertiesDialog';
 import { InviteManagerDialog } from './InviteManagerDialog';
 import { ShareDialog } from './ShareDialog';
 import { CascadePreviewDialog } from './CascadePreviewDialog';
-import type { Note, TreeNode, WorkspaceInfo, DeleteResult, SchemaInfo, DropIndicator, SchemaMigratedEvent, ReceivedResponseInfo, CascadeImpactRow } from '../types';
+import type { Note, TreeNode, WorkspaceInfo, DeleteResult, SchemaInfo, DropIndicator, SchemaMigratedEvent, ReceivedResponseInfo, CascadeImpactRow, SyncEvent } from '../types';
 import { DeleteStrategy } from '../types';
 import { buildTree, getDescendantIds } from '../utils/tree';
 import { getAvailableTypes, type NotePosition } from '../utils/noteTypes';
@@ -103,6 +103,10 @@ function WorkspaceView({ workspaceInfo, onOpenWorkspacePeers }: WorkspaceViewPro
 
   // Invite response toast state
   const [responseToasts, setResponseToasts] = useState<ReceivedResponseInfo[]>([]);
+
+  // Sync result toast state
+  interface SyncToast { sent: number; applied: number; errors: string[]; }
+  const [syncToasts, setSyncToasts] = useState<SyncToast[]>([]);
 
   // Workspace-level relay polling
   const [hasRelayPeers, setHasRelayPeers] = useState(false);
@@ -198,6 +202,22 @@ function WorkspaceView({ workspaceInfo, onOpenWorkspacePeers }: WorkspaceViewPro
       }
       if (event.payload === 'Edit > Workspace Properties clicked') {
         setShowWorkspaceProperties(true);
+      }
+      if (event.payload === 'File > Sync Now clicked') {
+        invoke<SyncEvent[]>('poll_sync').then(events => {
+          const sent = events.filter(e => e.type === 'delta_sent').length;
+          const applied = events.filter(e => e.type === 'bundle_applied').length;
+          const errors = events
+            .filter(e => e.type === 'sync_error' || e.type === 'ingest_error')
+            .map(e => e.error ?? 'unknown error');
+          const toast: SyncToast = { sent, applied, errors };
+          setSyncToasts(prev => [...prev, toast]);
+          setTimeout(() => setSyncToasts(prev => prev.filter(t => t !== toast)), 5000);
+        }).catch(err => {
+          const toast: SyncToast = { sent: 0, applied: 0, errors: [String(err)] };
+          setSyncToasts(prev => [...prev, toast]);
+          setTimeout(() => setSyncToasts(prev => prev.filter(t => t !== toast)), 5000);
+        });
       }
     });
 
@@ -923,6 +943,36 @@ function WorkspaceView({ workspaceInfo, onOpenWorkspacePeers }: WorkspaceViewPro
                   onClick={() => setResponseToasts(prev => prev.filter(t2 => t2 !== toast))}
                 >
                   {t("common.dismiss", "Dismiss")}
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Sync result toasts */}
+      {syncToasts.length > 0 && (
+        <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2">
+          {syncToasts.map((toast, i) => (
+            <div key={i} className={`bg-gray-800 border rounded-xl px-4 py-3 shadow-lg max-w-xs text-white ${toast.errors.length > 0 ? 'border-red-500' : 'border-green-600'}`}>
+              <div className="font-semibold text-sm">
+                {toast.errors.length > 0 ? t('peers.syncError', 'Sync error') : (toast.sent === 0 && toast.applied === 0 ? t('peers.syncNothingToSync', 'Nothing to sync') : t('peers.syncComplete', 'Sync complete'))}
+              </div>
+              {toast.errors.length > 0 ? (
+                <div className="text-xs text-red-300 mt-1">{toast.errors.join(', ')}</div>
+              ) : (toast.sent > 0 || toast.applied > 0) && (
+                <div className="text-xs text-gray-300 mt-1">
+                  {toast.sent > 0 && <span>{t('peers.syncSent', 'Sent {{count}} bundle(s)', { count: toast.sent })}</span>}
+                  {toast.sent > 0 && toast.applied > 0 && <span> · </span>}
+                  {toast.applied > 0 && <span>{t('peers.syncApplied', 'Applied {{count}} bundle(s)', { count: toast.applied })}</span>}
+                </div>
+              )}
+              <div className="flex gap-2 mt-2">
+                <button
+                  className="bg-transparent text-gray-400 border border-gray-600 text-xs px-3 py-1 rounded-md"
+                  onClick={() => setSyncToasts(prev => prev.filter(t2 => t2 !== toast))}
+                >
+                  {t('common.dismiss', 'Dismiss')}
                 </button>
               </div>
             </div>

--- a/krillnotes-desktop/src/hooks/useMenuEvents.ts
+++ b/krillnotes-desktop/src/hooks/useMenuEvents.ts
@@ -6,8 +6,9 @@
 
 import { useEffect, useRef } from 'react';
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
+import { invoke } from '@tauri-apps/api/core';
 import { open } from '@tauri-apps/plugin-dialog';
-import type { WorkspaceInfo as WorkspaceInfoType } from '../types';
+import type { WorkspaceInfo as WorkspaceInfoType, SyncEvent } from '../types';
 
 export interface MenuEventCallbacks {
   setShowNewWorkspace: (show: boolean) => void;
@@ -104,6 +105,22 @@ function createMenuHandlers(callbacks: MenuEventCallbacks) {
         openSwarmFile(picked as string);
       } catch {
         // user cancelled
+      }
+    },
+
+    'File > Sync Now clicked': async () => {
+      try {
+        const events = await invoke<SyncEvent[]>('poll_sync');
+        const sent = events.filter(e => e.type === 'delta_sent').length;
+        const applied = events.filter(e => e.type === 'bundle_applied').length;
+        const errors = events.filter(e => e.type === 'sync_error' || e.type === 'ingest_error');
+        if (errors.length > 0) {
+          statusSetter(`Sync errors: ${errors.map(e => e.error).join(', ')}`, true);
+        } else {
+          statusSetter(`Sync complete: sent ${sent} bundle(s), applied ${applied} bundle(s)`);
+        }
+      } catch (e) {
+        statusSetter(`Sync failed: ${String(e)}`, true);
       }
     },
   };

--- a/krillnotes-desktop/src/hooks/useMenuEvents.ts
+++ b/krillnotes-desktop/src/hooks/useMenuEvents.ts
@@ -6,9 +6,8 @@
 
 import { useEffect, useRef } from 'react';
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
-import { invoke } from '@tauri-apps/api/core';
 import { open } from '@tauri-apps/plugin-dialog';
-import type { WorkspaceInfo as WorkspaceInfoType, SyncEvent } from '../types';
+import type { WorkspaceInfo as WorkspaceInfoType } from '../types';
 
 export interface MenuEventCallbacks {
   setShowNewWorkspace: (show: boolean) => void;
@@ -108,21 +107,6 @@ function createMenuHandlers(callbacks: MenuEventCallbacks) {
       }
     },
 
-    'File > Sync Now clicked': async () => {
-      try {
-        const events = await invoke<SyncEvent[]>('poll_sync');
-        const sent = events.filter(e => e.type === 'delta_sent').length;
-        const applied = events.filter(e => e.type === 'bundle_applied').length;
-        const errors = events.filter(e => e.type === 'sync_error' || e.type === 'ingest_error');
-        if (errors.length > 0) {
-          statusSetter(`Sync errors: ${errors.map(e => e.error).join(', ')}`, true);
-        } else {
-          statusSetter(`Sync complete: sent ${sent} bundle(s), applied ${applied} bundle(s)`);
-        }
-      } catch (e) {
-        statusSetter(`Sync failed: ${String(e)}`, true);
-      }
-    },
   };
 }
 

--- a/krillnotes-desktop/src/i18n/locales/en.json
+++ b/krillnotes-desktop/src/i18n/locales/en.json
@@ -460,7 +460,12 @@
     "syncNow": "Sync Now",
     "syncing": "Syncing…",
     "configure": "Configure",
-    "forceResync": "Force Resync"
+    "forceResync": "Force Resync",
+    "syncComplete": "Sync complete",
+    "syncNothingToSync": "Nothing to sync",
+    "syncSent": "Sent {{count}} bundle(s)",
+    "syncApplied": "Applied {{count}} bundle(s)",
+    "syncError": "Sync error"
   },
   "workspacePeers": {
     "noRelayAccounts": "No relay accounts configured. Add one in Identity Manager → Relays.",

--- a/krillnotes-desktop/src/i18n/locales/en.json
+++ b/krillnotes-desktop/src/i18n/locales/en.json
@@ -321,7 +321,8 @@
     "aboutKrillnotes": "About Krillnotes",
     "createDeltaSwarm": "Create delta Swarm",
     "openSwarmFile": "Open .swarm File…",
-    "acceptInvite": "Accept Invite…"
+    "acceptInvite": "Accept Invite…",
+    "syncNow": "Sync Now"
   },
   "identity": {
     "manageTitle": "Identities",


### PR DESCRIPTION
Closes #115.

## Changes

- **File menu**: adds a "Sync Now" item with the `CmdOrCtrl+S` accelerator, disabled when no workspace is open
- **Workspace Peers dialog**: removes the Sync Now button and the inline sync result banner
- **`useMenuEvents`**: handles `File > Sync Now clicked` by calling `poll_sync` and reporting the result via the status bar

## Test plan

- [ ] Open a workspace → File > Sync Now should be enabled
- [ ] Press Cmd/Ctrl+S → sync runs and status bar shows result (e.g. "Sync complete: sent 0 bundle(s), applied 0 bundle(s)")
- [ ] Open Workspace Peers dialog → Sync Now button is gone
- [ ] No workspace open → File > Sync Now is greyed out