### PR TITLE
fix: show stored relay account in peer list dropdown

### DIFF
--- a/krillnotes-desktop/src/components/WorkspacePeersDialog.tsx
+++ b/krillnotes-desktop/src/components/WorkspacePeersDialog.tsx
@@ -306,6 +306,7 @@ export default function WorkspacePeersDialog({
             const dotClass = syncStatusDotClass(peer.syncStatus);
             const selectedChannelType = pendingChannelType[peer.peerDeviceId] ?? peer.channelType;
             const currentFolderPath = peer.channelType === 'folder' ? (() => { try { return JSON.parse(peer.channelParams).path as string ?? null; } catch { return null; } })() : null;
+            const currentRelayAccountId = peer.channelType === 'relay' ? (() => { try { return JSON.parse(peer.channelParams).relay_account_id as string ?? null; } catch { return null; } })() : null;
             return (
               <div
                 key={peer.peerDeviceId}
@@ -356,7 +357,7 @@ export default function WorkspacePeersDialog({
                         }
                       }}
                       relayAccounts={relayAccounts}
-                      selectedRelayAccountId={pendingRelayAccount[peer.peerDeviceId]}
+                      selectedRelayAccountId={pendingRelayAccount[peer.peerDeviceId] ?? currentRelayAccountId ?? undefined}
                       onRelayAccountSelect={async (accountId) => {
                         if (!accountId) return;
                         try {


### PR DESCRIPTION
## Summary
- Fixes #114 — relay dropdown in the workspace peer list was always empty on load
- Extracts the stored `relay_account_id` from `peer.channelParams` and uses it as the default `selectedRelayAccountId`, with `pendingRelayAccount` taking precedence only during active edits
- Mirrors the existing pattern used for `currentFolderPath` on the same component

## Test plan
- [ ] Open a workspace with a peer configured to sync via relay
- [ ] Verify the relay dropdown shows the correct relay account on load
- [ ] Change the relay account — verify the dropdown updates and persists after reopening