### PR TITLE
feat: sharing indicator visibility setting

### DIFF
--- a/krillnotes-desktop/src-tauri/src/settings.rs
+++ b/krillnotes-desktop/src-tauri/src/settings.rs
@@ -31,6 +31,10 @@ pub struct AppSettings {
     /// Language code for the UI ("en", "de", "fr", "es", "ja", "ko", "zh").
     #[serde(default = "default_language")]
     pub language: String,
+    /// Controls when sharing permission indicators (coloured dots) appear in the tree.
+    /// "on" = always, "off" = never, "auto" = only when the workspace has peers.
+    #[serde(default = "default_sharing_indicator_mode")]
+    pub sharing_indicator_mode: String,
 }
 
 impl Default for AppSettings {
@@ -43,6 +47,7 @@ impl Default for AppSettings {
             light_theme: default_light_theme(),
             dark_theme: default_dark_theme(),
             language: default_language(),
+            sharing_indicator_mode: default_sharing_indicator_mode(),
         }
     }
 }
@@ -84,6 +89,7 @@ fn default_theme_mode() -> String { "system".to_string() }
 fn default_light_theme() -> String { "light".to_string() }
 fn default_dark_theme() -> String { "dark".to_string() }
 fn default_language() -> String { "en".to_string() }
+fn default_sharing_indicator_mode() -> String { "auto".to_string() }
 
 /// Returns the default workspace directory: `~/Documents/Krillnotes`.
 pub fn default_workspace_directory() -> PathBuf {
@@ -137,6 +143,13 @@ mod tests {
         let json = r#"{"workspaceDirectory":"/tmp"}"#;
         let s: AppSettings = serde_json::from_str(json).unwrap();
         assert_eq!(s.language, "en");
+    }
+
+    #[test]
+    fn deserializes_legacy_settings_without_sharing_indicator_mode_field() {
+        let json = r#"{"workspaceDirectory":"/tmp"}"#;
+        let s: AppSettings = serde_json::from_str(json).unwrap();
+        assert_eq!(s.sharing_indicator_mode, "auto");
     }
 
     #[test]

--- a/krillnotes-desktop/src/App.tsx
+++ b/krillnotes-desktop/src/App.tsx
@@ -5,6 +5,7 @@
 // Copyright (c) 2024-2026 TripleACS Pty Ltd t/a 2pi Software
 
 
+import { useState, useEffect } from 'react';
 import { save, confirm } from '@tauri-apps/plugin-dialog';
 import { invoke } from '@tauri-apps/api/core';
 import WorkspaceView from './components/WorkspaceView';
@@ -68,6 +69,14 @@ function App() {
 
   // Global snapshot polling for all unlocked identities (no workspace needed).
   useGlobalSnapshotPolling();
+
+  const [sharingIndicatorMode, setSharingIndicatorMode] = useState<'off' | 'auto' | 'on'>('auto');
+  const refreshSharingIndicatorMode = () => {
+    invoke<AppSettings>('get_settings')
+      .then(s => setSharingIndicatorMode((s.sharingIndicatorMode ?? 'auto') as 'off' | 'auto' | 'on'))
+      .catch(() => {});
+  };
+  useEffect(refreshSharingIndicatorMode, []);
 
   const handleImportConfirm = async () => {
     if (!importState) return;
@@ -198,7 +207,7 @@ function App() {
   return (
     <ThemeProvider>
     <div className="min-h-screen bg-background text-foreground">
-      {workspace ? <WorkspaceView workspaceInfo={workspace} onOpenWorkspacePeers={() => setShowWorkspacePeers(true)} /> : <div className="p-8"><EmptyState /></div>}
+      {workspace ? <WorkspaceView workspaceInfo={workspace} onOpenWorkspacePeers={() => setShowWorkspacePeers(true)} sharingIndicatorMode={sharingIndicatorMode} /> : <div className="p-8"><EmptyState /></div>}
       {status && <StatusMessage message={status} isError={isError} />}
 
       <NewWorkspaceDialog
@@ -216,6 +225,7 @@ function App() {
       <SettingsDialog
         isOpen={showSettings}
         onClose={() => setShowSettings(false)}
+        onSaved={refreshSharingIndicatorMode}
       />
 
       {/* Export password dialog */}

--- a/krillnotes-desktop/src/components/SettingsDialog.tsx
+++ b/krillnotes-desktop/src/components/SettingsDialog.tsx
@@ -16,9 +16,10 @@ import { useTranslation } from 'react-i18next';
 interface SettingsDialogProps {
   isOpen: boolean;
   onClose: () => void;
+  onSaved?: () => void;
 }
 
-function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
+function SettingsDialog({ isOpen, onClose, onSaved }: SettingsDialogProps) {
   const { t } = useTranslation();
   const [workspaceDir, setWorkspaceDir] = useState('');
   const [error, setError] = useState('');
@@ -29,6 +30,7 @@ function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
   const [manageThemesOpen, setManageThemesOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<'general' | 'appearance'>('general');
   const [undoLimit, setUndoLimit] = useState<number | undefined>(undefined);
+  const [sharingIndicatorMode, setSharingIndicatorMode] = useState<'off' | 'auto' | 'on'>('auto');
 
   useEffect(() => {
     if (isOpen) {
@@ -37,6 +39,7 @@ function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
           setWorkspaceDir(s.workspaceDirectory);
           setLanguage(s.language ?? 'en');
           setOriginalLanguage(s.language ?? 'en');
+          setSharingIndicatorMode((s.sharingIndicatorMode ?? 'auto') as 'off' | 'auto' | 'on');
           setError('');
         })
         .catch(err => setError(t('settings.failedLoad', { error: String(err) })));
@@ -87,12 +90,14 @@ function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
         patch: {
           workspaceDirectory: workspaceDir,
           language,
+          sharingIndicatorMode,
         },
       });
       if (undoLimit !== undefined) {
         await invoke('set_undo_limit', { limit: undoLimit });
       }
       setOriginalLanguage(language); // committed — no revert on close
+      onSaved?.();
       onClose();
     } catch (err) {
       setError(t('settings.failedSave', { error: String(err) }));
@@ -217,6 +222,26 @@ function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
                     }`}
                   >
                     {t(`settings.mode${m.charAt(0).toUpperCase() + m.slice(1)}`)}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Sharing indicators toggle */}
+            <div className="flex items-center gap-2 mb-3">
+              <span className="text-sm text-muted-foreground w-24">{t('settings.sharingIndicators')}</span>
+              <div className="flex rounded border border-border overflow-hidden">
+                {(['off', 'auto', 'on'] as const).map(m => (
+                  <button
+                    key={m}
+                    onClick={() => setSharingIndicatorMode(m)}
+                    className={`px-3 py-1 text-sm ${
+                      sharingIndicatorMode === m
+                        ? 'bg-primary text-primary-foreground'
+                        : 'text-muted-foreground hover:text-foreground hover:bg-secondary'
+                    }`}
+                  >
+                    {t(`settings.sharingIndicators${m.charAt(0).toUpperCase() + m.slice(1)}`)}
                   </button>
                 ))}
               </div>

--- a/krillnotes-desktop/src/components/TreeNode.tsx
+++ b/krillnotes-desktop/src/components/TreeNode.tsx
@@ -27,12 +27,13 @@ interface TreeNodeProps {
   onHoverEnd: () => void;
   effectiveRoles?: Record<string, string>;
   shareAnchorIds?: Set<string>;
+  showSharingIndicators?: boolean;
 }
 
 function TreeNode({
   node, selectedNoteId, level, onSelect, onToggleExpand, onContextMenu,
   notes, schemas, draggedNoteId, setDraggedNoteId, dropIndicator, setDropIndicator, dragDescendants, onMoveNote,
-  onHoverStart, onHoverEnd, effectiveRoles, shareAnchorIds,
+  onHoverStart, onHoverEnd, effectiveRoles, shareAnchorIds, showSharingIndicators,
 }: TreeNodeProps) {
   const { t } = useTranslation();
   const hasChildren = node.children.length > 0;
@@ -247,14 +248,14 @@ function TreeNode({
           </button>
         )}
         {!hasChildren && <span className="w-4 mr-1" />}
-        {!isGhost && role && (
+        {showSharingIndicators && !isGhost && role && (
           <span className={`text-[10px] mr-1 flex-shrink-0 ${
             role === 'owner' || role === 'root_owner' ? 'text-green-500' :
             role === 'writer' ? 'text-orange-500' :
             role === 'reader' ? 'text-yellow-500' : ''
           }`}>●</span>
         )}
-        {isShareAnchor && (role === 'owner' || role === 'root_owner') && (
+        {showSharingIndicators && isShareAnchor && (role === 'owner' || role === 'root_owner') && (
           <span className="text-[10px] mr-1 flex-shrink-0 text-zinc-400" title={t('tree.sharedSubtree', 'Shared subtree')}>👥</span>
         )}
         <span className={`text-sm truncate flex-1 min-w-0 ${isGhost ? 'text-zinc-400 italic' : ''}`}>{node.note.title}</span>
@@ -288,6 +289,7 @@ function TreeNode({
               onHoverEnd={onHoverEnd}
               effectiveRoles={effectiveRoles}
               shareAnchorIds={shareAnchorIds}
+              showSharingIndicators={showSharingIndicators}
             />
           ))}
         </div>

--- a/krillnotes-desktop/src/components/TreeView.tsx
+++ b/krillnotes-desktop/src/components/TreeView.tsx
@@ -28,12 +28,13 @@ interface TreeViewProps {
   onHoverEnd: () => void;
   effectiveRoles?: Record<string, string>;
   shareAnchorIds?: Set<string>;
+  showSharingIndicators?: boolean;
 }
 
 function TreeView({
   tree, selectedNoteId, onSelect, onToggleExpand, onContextMenu, onKeyDown,
   notes, schemas, draggedNoteId, setDraggedNoteId, dropIndicator, setDropIndicator, dragDescendants, onMoveNote,
-  onBackgroundContextMenu, onHoverStart, onHoverEnd, effectiveRoles, shareAnchorIds,
+  onBackgroundContextMenu, onHoverStart, onHoverEnd, effectiveRoles, shareAnchorIds, showSharingIndicators,
 }: TreeViewProps) {
   const { t } = useTranslation();
 
@@ -119,6 +120,7 @@ function TreeView({
           onHoverEnd={onHoverEnd}
           effectiveRoles={effectiveRoles}
           shareAnchorIds={shareAnchorIds}
+          showSharingIndicators={showSharingIndicators}
         />
       ))}
       {draggedNoteId && dropIndicator?.noteId === '__root__' && (

--- a/krillnotes-desktop/src/components/WorkspaceView.tsx
+++ b/krillnotes-desktop/src/components/WorkspaceView.tsx
@@ -37,9 +37,10 @@ import TagPill from './TagPill';
 interface WorkspaceViewProps {
   workspaceInfo: WorkspaceInfo;
   onOpenWorkspacePeers?: () => void;
+  sharingIndicatorMode?: 'off' | 'auto' | 'on';
 }
 
-function WorkspaceView({ workspaceInfo, onOpenWorkspacePeers }: WorkspaceViewProps) {
+function WorkspaceView({ workspaceInfo, onOpenWorkspacePeers, sharingIndicatorMode = 'auto' }: WorkspaceViewProps) {
   const { t } = useTranslation();
   const [notes, setNotes] = useState<Note[]>([]);
   const [schemas, setSchemas] = useState<Record<string, SchemaInfo>>({});
@@ -50,6 +51,7 @@ function WorkspaceView({ workspaceInfo, onOpenWorkspacePeers }: WorkspaceViewPro
   const [shareAnchorIds, setShareAnchorIds] = useState<Set<string>>(new Set());
   const [isRootOwner, setIsRootOwner] = useState(false);
   const [permissionRefreshSignal, setPermissionRefreshSignal] = useState(0);
+  const [hasPeers, setHasPeers] = useState(false);
   const treePanelRef = useRef<HTMLDivElement>(null);
   const [showAddDialog, setShowAddDialog] = useState(false);
   const [addDialogNoteId, setAddDialogNoteId] = useState<string | null>(null);
@@ -180,6 +182,7 @@ function WorkspaceView({ workspaceInfo, onOpenWorkspacePeers }: WorkspaceViewPro
       invoke<any[]>("list_workspace_peers").catch(() => []),
       invoke<boolean>("has_relay_credentials").catch(() => false),
     ]).then(([peers, hasCreds]) => {
+      setHasPeers((peers as any[]).length > 0);
       setHasRelayPeers(
         (peers as any[]).some((p: any) => p.channelType !== "manual") || (hasCreds as boolean)
       );
@@ -726,6 +729,11 @@ function WorkspaceView({ workspaceInfo, onOpenWorkspacePeers }: WorkspaceViewPro
             onHoverEnd={handleHoverEnd}
             effectiveRoles={effectiveRoles}
             shareAnchorIds={shareAnchorIds}
+            showSharingIndicators={
+              sharingIndicatorMode === 'on' ? true :
+              sharingIndicatorMode === 'off' ? false :
+              hasPeers
+            }
           />
         </div>
 

--- a/krillnotes-desktop/src/i18n/locales/en.json
+++ b/krillnotes-desktop/src/i18n/locales/en.json
@@ -49,7 +49,11 @@
     "tabGeneral": "General",
     "tabAppearance": "Appearance",
     "undoHistoryLimit": "Undo history limit",
-    "undoHistoryLimitHint": "Number of actions that can be undone (1–500)"
+    "undoHistoryLimitHint": "Number of actions that can be undone (1–500)",
+    "sharingIndicators": "Sharing indicators",
+    "sharingIndicatorsOff": "Off",
+    "sharingIndicatorsAuto": "Auto",
+    "sharingIndicatorsOn": "On"
   },
   "themes": {
     "manage": "Manage Themes",

--- a/krillnotes-desktop/src/types.ts
+++ b/krillnotes-desktop/src/types.ts
@@ -166,6 +166,7 @@ export interface AppSettings {
   lightTheme?: string;
   darkTheme?: string;
   language?: string;
+  sharingIndicatorMode?: string;
 }
 
 export interface WorkspaceEntry {


### PR DESCRIPTION
Closes #111

## Summary

- Adds `sharingIndicatorMode` (`"off"` / `"auto"` / `"on"`) to `AppSettings` (Rust + TS), defaulting to `"auto"` with backward-compatible `#[serde(default)]`
- New **Off / Auto / On** button group in Settings → Appearance, styled identically to the Mode (Light/Dark/System) toggle
- **Auto** (default): indicators shown only when the workspace has at least one peer — solo users see a clean tree without any config
- **On**: always show the coloured dots and 👥 icon (previous behaviour)
- **Off**: never show them
- `App.tsx` loads the setting on startup and refreshes it when the Settings dialog is saved, so changes take effect immediately without reloading
- Both the coloured permission dot (`●`) and the shared-subtree icon (`👥`) are gated by the setting

## Test plan

- [ ] Open settings → Appearance, verify Off/Auto/On toggle appears below Mode
- [ ] Set to **Off** — no dots or icons in tree regardless of peers
- [ ] Set to **On** — dots always visible
- [ ] Set to **Auto** with no peers — no dots shown; add a peer, reopen workspace — dots appear
- [ ] Verify old settings files without `sharingIndicatorMode` key default to `"auto"` (covered by new unit test)
- [ ] Verify all 4 settings Rust unit tests pass