### PR TITLE
fix: ShareDialog ignores app theme setting (uses system dark mode instead)

### DIFF
--- a/krillnotes-desktop/src/components/ShareDialog.tsx
+++ b/krillnotes-desktop/src/components/ShareDialog.tsx
@@ -71,11 +71,11 @@ export function ShareDialog({
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-white dark:bg-zinc-900 rounded-xl shadow-xl p-6 w-full max-w-md">
+      <div className="bg-[var(--color-background)] border border-[var(--color-border)] rounded-xl shadow-xl p-6 w-full max-w-md">
         <h2 className="text-lg font-semibold mb-1">
           {t('share.title', 'Share subtree')}
         </h2>
-        <p className="text-xs text-zinc-500 mb-4">{noteTitle}</p>
+        <p className="text-xs text-[var(--color-muted-foreground)] mb-4">{noteTitle}</p>
 
         {/* Search */}
         <input
@@ -83,13 +83,13 @@ export function ShareDialog({
           placeholder={t('share.searchPeers', 'Search peers...')}
           value={search}
           onChange={e => setSearch(e.target.value)}
-          className="w-full border rounded px-3 py-2 text-sm mb-2 dark:bg-zinc-800 dark:border-zinc-700"
+          className="w-full border border-[var(--color-border)] bg-[var(--color-background)] rounded px-3 py-2 text-sm mb-2"
         />
 
         {/* Peer list */}
-        <div className="max-h-40 overflow-y-auto border rounded dark:border-zinc-700 mb-3">
+        <div className="max-h-40 overflow-y-auto border border-[var(--color-border)] rounded mb-3">
           {availablePeers.length === 0 ? (
-            <p className="text-xs text-zinc-400 p-3 text-center">
+            <p className="text-xs text-[var(--color-muted-foreground)] p-3 text-center">
               {t('share.noPeers', 'No available peers')}
             </p>
           ) : (
@@ -99,19 +99,19 @@ export function ShareDialog({
                 onClick={() => setSelectedPeerId(peer.peerIdentityId)}
                 className={`w-full text-left px-3 py-2 text-sm flex items-center gap-2 ${
                   selectedPeerId === peer.peerIdentityId
-                    ? 'bg-blue-50 dark:bg-blue-900/30'
-                    : 'hover:bg-zinc-50 dark:hover:bg-zinc-800'
+                    ? 'bg-blue-500/20'
+                    : 'hover:bg-[var(--color-secondary)]'
                 }`}
               >
                 <span className="flex-1 truncate">{peer.displayName}</span>
-                <span className="text-xs text-zinc-400 font-mono">
+                <span className="text-xs text-[var(--color-muted-foreground)] font-mono">
                   {peer.fingerprint?.slice(0, 8) ?? ''}
                 </span>
               </button>
             ))
           )}
         </div>
-        <p className="text-xs text-zinc-400 mb-3">
+        <p className="text-xs text-[var(--color-muted-foreground)] mb-3">
           {t('share.peerCount', '{{available}} of {{total}} peers', { available: availablePeers.length, total: peers.length })}
         </p>
 
@@ -121,7 +121,7 @@ export function ShareDialog({
             {t('share.role', 'Role')}
           </label>
           <select
-            className="w-full border rounded px-3 py-2 dark:bg-zinc-800 dark:border-zinc-700"
+            className="w-full border border-[var(--color-border)] bg-[var(--color-background)] rounded px-3 py-2"
             value={role}
             onChange={e => setRole(e.target.value)}
             disabled={processing}
@@ -141,7 +141,7 @@ export function ShareDialog({
           <button
             onClick={onClose}
             disabled={processing}
-            className="px-4 py-2 text-sm rounded border dark:border-zinc-700 disabled:opacity-50"
+            className="px-4 py-2 text-sm rounded border border-[var(--color-border)] disabled:opacity-50"
           >
             {t('common.cancel', 'Cancel')}
           </button>


### PR DESCRIPTION
## Problem

The Share subtree dialog used Tailwind `dark:` variants (`dark:bg-zinc-900`, `dark:bg-zinc-800`, `dark:border-zinc-700`, etc.) which respond to the **system** `prefers-color-scheme` media query. Every other dialog in the app uses `var(--color-background)` and `var(--color-border)` CSS variables that track the app's own theme setting.

Result: with system in dark mode but app theme set to **light**, the Share dialog appeared dark while everything else was light.

## Fix

Replace all `dark:` classes and hardcoded `bg-white`/`zinc-*` colours with the same CSS variable conventions used by every other dialog:
- `bg-white dark:bg-zinc-900` → `bg-[var(--color-background)]`
- `dark:border-zinc-700` → `border-[var(--color-border)]`
- `dark:bg-zinc-800` → `bg-[var(--color-background)]`
- `text-zinc-400/500` → `text-[var(--color-muted-foreground)]`
- `hover:bg-zinc-50 dark:hover:bg-zinc-800` → `hover:bg-[var(--color-secondary)]`
- `bg-blue-50 dark:bg-blue-900/30` → `bg-blue-500/20`