### PR TITLE
fix: rename script category "presentation" → "library"

### DIFF
--- a/krillnotes-core/src/core/export_tests.rs
+++ b/krillnotes-core/src/core/export_tests.rs
@@ -187,16 +187,16 @@
     #[test]
     fn test_round_trip_preserves_script_category() {
         // Regression test: imported scripts must retain their original category.
-        // Previously all scripts were hardcoded to "presentation" on import, which
+        // Previously all scripts were hardcoded to "library" on import, which
         // caused schema() scripts to fail with "can only be called from schema-category scripts".
         let temp_src = NamedTempFile::new().unwrap();
         let mut ws = Workspace::create(temp_src.path(), "", "test-identity", ed25519_dalek::SigningKey::from_bytes(&[1u8; 32]), test_gate(), None).unwrap();
 
         let schema_src = "// @name: My Schema\n// @description: A schema script\nschema(\"MyType\", #{ version: 1, fields: [] });";
-        let lib_src = "// @name: My Library\n// @description: A presentation script\nfn my_helper() { \"hello\" }";
+        let lib_src = "// @name: My Library\n// @description: A library script\nfn my_helper() { \"hello\" }";
 
         ws.create_user_script_with_category(schema_src, "schema").unwrap();
-        ws.create_user_script_with_category(lib_src, "presentation").unwrap();
+        ws.create_user_script_with_category(lib_src, "library").unwrap();
 
         let mut buf = Vec::new();
         export_workspace(&ws, Cursor::new(&mut buf), None).unwrap();
@@ -211,7 +211,7 @@
         let lib_script = scripts.iter().find(|s| s.name == "My Library").unwrap();
 
         assert_eq!(schema_script.category, "schema", "schema script category must survive export/import round-trip");
-        assert_eq!(lib_script.category, "presentation", "presentation script category must survive export/import round-trip");
+        assert_eq!(lib_script.category, "library", "library script category must survive export/import round-trip");
     }
 
     #[test]

--- a/krillnotes-core/src/core/scripting/engine.rs
+++ b/krillnotes-core/src/core/scripting/engine.rs
@@ -151,8 +151,8 @@ impl ScriptRegistry {
         engine.register_fn("schema", move |name: String, def: rhai::Map| -> std::result::Result<Dynamic, Box<EvalAltResult>> {
             // Gate: schema() can only be called from schema-category scripts.
             let cat = schema_cat_arc.lock().unwrap();
-            if cat.as_deref() == Some("presentation") {
-                return Err("schema() can only be called from schema-category scripts, not presentation/library scripts".into());
+            if cat.as_deref() == Some("library") {
+                return Err("schema() can only be called from schema-category scripts, not library scripts".into());
             }
             drop(cat);
 

--- a/krillnotes-core/src/core/scripting/mod.rs
+++ b/krillnotes-core/src/core/scripting/mod.rs
@@ -139,7 +139,7 @@ pub struct ScriptRegistry {
     current_loading_ast: Arc<Mutex<Option<AST>>>,
     current_loading_script_name: Arc<Mutex<Option<String>>>,
     current_loading_category: Arc<Mutex<Option<String>>>,
-    /// Source code of all successfully loaded library/presentation scripts.
+    /// Source code of all successfully loaded library scripts.
     /// Schema scripts are compiled together with this library source so they can call library
     /// helpers at both load time and at runtime (the merged AST is stored in every hook entry).
     library_sources: Arc<Mutex<Vec<String>>>,
@@ -216,7 +216,7 @@ impl ScriptRegistry {
             .eval_ast::<()>(&ast)
             .map_err(|e| KrillnotesError::Scripting(e.to_string()));
 
-        // Accumulate successful library/presentation scripts so later schema scripts can use them.
+        // Accumulate successful library scripts so later schema scripts can use them.
         if result.is_ok() && !is_schema {
             self.library_sources.lock().unwrap().push(script.to_string());
         }

--- a/krillnotes-core/src/core/scripting/tests.rs
+++ b/krillnotes-core/src/core/scripting/tests.rs
@@ -5,7 +5,7 @@
         registry.load_script(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/src/system_scripts/00_text_note.rhai"
-        )), "Text Note Actions").expect("TextNote presentation script should load");
+        )), "Text Note Actions").expect("TextNote library script should load");
         registry.load_script(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/src/system_scripts/00_text_note.schema.rhai"
@@ -634,15 +634,15 @@
         assert!(types.is_empty(), "clear_all should remove all schemas");
     }
 
-    /// Regression: library scripts (presentation category) define functions that schema scripts
+    /// Regression: library scripts (library category) define functions that schema scripts
     /// should be able to call.  Before the fix, function definitions from a separately-eval'd
     /// library AST were not visible when the schema AST was compiled and executed.
     #[test]
     fn test_schema_script_can_call_library_script_functions() {
         let mut registry = ScriptRegistry::new().unwrap();
 
-        // Load a library/presentation script that defines a helper function.
-        registry.set_loading_category(Some("presentation".to_string()));
+        // Load a library script that defines a helper function.
+        registry.set_loading_category(Some("library".to_string()));
         registry.load_script(r#"
             fn format_greeting(name) {
                 "Hello, " + name
@@ -683,7 +683,7 @@
     fn test_clear_all_resets_library_sources() {
         let mut registry = ScriptRegistry::new().unwrap();
 
-        registry.set_loading_category(Some("presentation".to_string()));
+        registry.set_loading_category(Some("library".to_string()));
         registry.load_script("fn lib_fn() { 42 }", "lib").unwrap();
 
         registry.clear_all();
@@ -1016,7 +1016,7 @@
         registry.load_script(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/../example-scripts/book-collection/book-collection.rhai"
-        )), "Book Collection Views").expect("Book presentation script should load");
+        )), "Book Collection Views").expect("Book library script should load");
         registry.load_script(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/../example-scripts/book-collection/book-collection.schema.rhai"

--- a/krillnotes-core/src/core/storage.rs
+++ b/krillnotes-core/src/core/storage.rs
@@ -304,10 +304,16 @@ impl Storage {
         )?;
         if !category_exists {
             conn.execute(
-                "ALTER TABLE user_scripts ADD COLUMN category TEXT NOT NULL DEFAULT 'presentation'",
+                "ALTER TABLE user_scripts ADD COLUMN category TEXT NOT NULL DEFAULT 'library'",
                 [],
             )?;
         }
+
+        // Migration: rename category "presentation" → "library" for consistency with UI.
+        conn.execute(
+            "UPDATE user_scripts SET category = 'library' WHERE category = 'presentation'",
+            [],
+        )?;
 
         // Migration: add schema_version column to notes if absent.
         let schema_version_exists: bool = conn.query_row(

--- a/krillnotes-core/src/core/user_script.rs
+++ b/krillnotes-core/src/core/user_script.rs
@@ -20,7 +20,7 @@ pub struct UserScript {
     pub enabled: bool,
     pub created_at: i64,
     pub modified_at: i64,
-    pub category: String, // "schema" or "presentation"
+    pub category: String, // "schema" or "library"
 }
 
 /// Parsed front-matter metadata from a script's leading comments.

--- a/krillnotes-core/src/core/workspace/mod.rs
+++ b/krillnotes-core/src/core/workspace/mod.rs
@@ -184,7 +184,7 @@ impl Workspace {
             for (load_order, starter) in starters.iter().enumerate() {
                 let fm = user_script::parse_front_matter(&starter.source_code);
                 let id = Uuid::new_v4().to_string();
-                let category = if starter.filename.ends_with(".schema.rhai") { "schema" } else { "presentation" };
+                let category = if starter.filename.ends_with(".schema.rhai") { "schema" } else { "library" };
                 tx.execute(
                     "INSERT INTO user_scripts (id, name, description, source_code, load_order, enabled, created_at, modified_at, category)
                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -210,15 +210,15 @@ impl Workspace {
                     enabled: row.get::<_, i64>(5).map(|v| v != 0)?,
                     created_at: row.get(6)?,
                     modified_at: row.get(7)?,
-                    category: row.get::<_, String>(8).unwrap_or_else(|_| "presentation".to_string()),
+                    category: row.get::<_, String>(8).unwrap_or_else(|_| "library".to_string()),
                 })
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
             results
         };
-        // Two-phase loading: presentation first, then schema, then resolve.
-        for script in scripts.iter().filter(|s| s.enabled && s.category == "presentation") {
-            script_registry.set_loading_category(Some("presentation".to_string()));
+        // Two-phase loading: library first, then schema, then resolve.
+        for script in scripts.iter().filter(|s| s.enabled && s.category == "library") {
+            script_registry.set_loading_category(Some("library".to_string()));
             if let Err(e) = script_registry.load_script(&script.source_code, &script.name) {
                 log::warn!("Failed to load starter script '{}': {}", script.name, e);
             }
@@ -407,7 +407,7 @@ impl Workspace {
             for (load_order, starter) in starters.iter().enumerate() {
                 let fm = user_script::parse_front_matter(&starter.source_code);
                 let id = Uuid::new_v4().to_string();
-                let category = if starter.filename.ends_with(".schema.rhai") { "schema" } else { "presentation" };
+                let category = if starter.filename.ends_with(".schema.rhai") { "schema" } else { "library" };
                 tx.execute(
                     "INSERT INTO user_scripts (id, name, description, source_code, load_order, enabled, created_at, modified_at, category)
                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -433,15 +433,15 @@ impl Workspace {
                     enabled: row.get::<_, i64>(5).map(|v| v != 0)?,
                     created_at: row.get(6)?,
                     modified_at: row.get(7)?,
-                    category: row.get::<_, String>(8).unwrap_or_else(|_| "presentation".to_string()),
+                    category: row.get::<_, String>(8).unwrap_or_else(|_| "library".to_string()),
                 })
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
             results
         };
-        // Two-phase loading: presentation first, then schema, then resolve.
-        for script in scripts.iter().filter(|s| s.enabled && s.category == "presentation") {
-            script_registry.set_loading_category(Some("presentation".to_string()));
+        // Two-phase loading: library first, then schema, then resolve.
+        for script in scripts.iter().filter(|s| s.enabled && s.category == "library") {
+            script_registry.set_loading_category(Some("library".to_string()));
             if let Err(e) = script_registry.load_script(&script.source_code, &script.name) {
                 log::warn!("Failed to load starter script '{}': {}", script.name, e);
             }
@@ -619,7 +619,7 @@ impl Workspace {
             for (load_order, starter) in starters.iter().enumerate() {
                 let fm = user_script::parse_front_matter(&starter.source_code);
                 let id = Uuid::new_v4().to_string();
-                let category = if starter.filename.ends_with(".schema.rhai") { "schema" } else { "presentation" };
+                let category = if starter.filename.ends_with(".schema.rhai") { "schema" } else { "library" };
                 tx.execute(
                     "INSERT INTO user_scripts (id, name, description, source_code, load_order, enabled, created_at, modified_at, category)
                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -644,14 +644,14 @@ impl Workspace {
                     enabled: row.get::<_, i64>(5).map(|v| v != 0)?,
                     created_at: row.get(6)?,
                     modified_at: row.get(7)?,
-                    category: row.get::<_, String>(8).unwrap_or_else(|_| "presentation".to_string()),
+                    category: row.get::<_, String>(8).unwrap_or_else(|_| "library".to_string()),
                 })
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
             results
         };
-        for script in scripts.iter().filter(|s| s.enabled && s.category == "presentation") {
-            script_registry.set_loading_category(Some("presentation".to_string()));
+        for script in scripts.iter().filter(|s| s.enabled && s.category == "library") {
+            script_registry.set_loading_category(Some("library".to_string()));
             let _ = script_registry.load_script(&script.source_code, &script.name);
         }
         for script in scripts.iter().filter(|s| s.enabled && s.category == "schema") {
@@ -989,10 +989,10 @@ impl Workspace {
             permission_gate,
         };
 
-        // Two-phase script loading: presentation first, then schema, then resolve.
+        // Two-phase script loading: library first, then schema, then resolve.
         let scripts = ws.list_user_scripts()?;
-        for script in scripts.iter().filter(|s| s.enabled && s.category == "presentation") {
-            ws.script_registry.set_loading_category(Some("presentation".to_string()));
+        for script in scripts.iter().filter(|s| s.enabled && s.category == "library") {
+            ws.script_registry.set_loading_category(Some("library".to_string()));
             if let Err(e) = ws.script_registry.load_script(&script.source_code, &script.name) {
                 log::warn!("Failed to load script '{}': {}", script.name, e);
             }

--- a/krillnotes-core/src/core/workspace/scripts.rs
+++ b/krillnotes-core/src/core/workspace/scripts.rs
@@ -28,7 +28,7 @@ impl Workspace {
                     enabled: row.get::<_, i64>(5).map(|v| v != 0)?,
                     created_at: row.get(6)?,
                     modified_at: row.get(7)?,
-                    category: row.get::<_, String>(8).unwrap_or_else(|_| "presentation".to_string()),
+                    category: row.get::<_, String>(8).unwrap_or_else(|_| "library".to_string()),
                 })
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -52,7 +52,7 @@ impl Workspace {
                         enabled: row.get::<_, i64>(5).map(|v| v != 0)?,
                         created_at: row.get(6)?,
                         modified_at: row.get(7)?,
-                        category: row.get::<_, String>(8).unwrap_or_else(|_| "presentation".to_string()),
+                        category: row.get::<_, String>(8).unwrap_or_else(|_| "library".to_string()),
                     })
                 },
             )
@@ -65,11 +65,11 @@ impl Workspace {
     /// compilation fails. On failure nothing is written to the database.
     pub fn create_user_script(&mut self, source_code: &str) -> Result<(UserScript, Vec<ScriptError>)> {
         // Auto-detect category: if the source calls schema(), it's a schema script.
-        let category = if source_code.contains("schema(") { "schema" } else { "presentation" };
+        let category = if source_code.contains("schema(") { "schema" } else { "library" };
         self.create_user_script_with_category(source_code, category)
     }
 
-    /// Creates a user script with an explicit category ("schema" or "presentation").
+    /// Creates a user script with an explicit category ("schema" or "library").
     pub fn create_user_script_with_category(
         &mut self,
         source_code: &str,
@@ -199,7 +199,7 @@ impl Workspace {
         let existing_category = self
             .get_user_script(script_id)
             .map(|s| s.category)
-            .unwrap_or_else(|_| "presentation".to_string());
+            .unwrap_or_else(|_| "library".to_string());
         self.script_registry.set_loading_category(Some(existing_category));
         if let Err(e) = self.script_registry.load_script(source_code, &fm.name) {
             let _ = self.reload_scripts(); // restore registry; ignore restoration errors
@@ -513,13 +513,13 @@ impl Workspace {
         Ok(self.load_scripts_two_phase(&scripts))
     }
 
-    /// Two-phase script loading: presentation/library first, then schema, then resolve bindings.
+    /// Two-phase script loading: library first, then schema, then resolve bindings.
     fn load_scripts_two_phase(&mut self, scripts: &[UserScript]) -> Vec<ScriptError> {
         let mut errors = Vec::new();
 
-        // Phase A: load presentation/library scripts first
-        for script in scripts.iter().filter(|s| s.enabled && s.category == "presentation") {
-            self.script_registry.set_loading_category(Some("presentation".to_string()));
+        // Phase A: load library scripts first
+        for script in scripts.iter().filter(|s| s.enabled && s.category == "library") {
+            self.script_registry.set_loading_category(Some("library".to_string()));
             if let Err(e) = self.script_registry.load_script(&script.source_code, &script.name) {
                 errors.push(ScriptError {
                     script_name: script.name.clone(),

--- a/krillnotes-core/src/core/workspace/undo.rs
+++ b/krillnotes-core/src/core/workspace/undo.rs
@@ -543,7 +543,7 @@ impl Workspace {
                      VALUES (?,?,?,?,?,?,?,?,?)",
                     rusqlite::params![
                         script_id, name, description, source_code,
-                        load_order, enabled, now, now, "presentation",
+                        load_order, enabled, now, now, "library",
                     ],
                 )?;
                 self.reload_scripts()?;


### PR DESCRIPTION
## Summary
- Renames the internal DB/Rust category value from `"presentation"` to `"library"` to match the frontend UI label (`t('scripts.library')`)
- Adds a DB migration to update existing rows (`UPDATE user_scripts SET category = 'library' WHERE category = 'presentation'`)
- Updates all 9 affected Rust source/test files (string literals, comments, assertions)

## Test plan
- [x] `cargo check -p krillnotes-core` — clean compile
- [x] `cargo test -p krillnotes-core` — 589 tests passing
- [ ] Manual: open workspace with existing scripts, verify Script Manager shows correct category badges