### PR TITLE
fix: resolve Tauri command issues C6, C7, M17, M18

### DIFF
--- a/krillnotes-core/src/core/workspace/mod.rs
+++ b/krillnotes-core/src/core/workspace/mod.rs
@@ -727,6 +727,7 @@ impl Workspace {
             "created_at": created_at,
             "note_count": note_count,
             "attachment_count": attachment_count,
+            "is_owner": self.is_owner(),
         });
 
         let path = self.workspace_root().join("info.json");

--- a/krillnotes-desktop/src-tauri/src/commands/contacts.rs
+++ b/krillnotes-desktop/src-tauri/src/commands/contacts.rs
@@ -162,7 +162,7 @@ pub fn list_workspace_peers(
         let paths = state.workspace_paths.lock().expect("Mutex poisoned");
         let folder = paths.get(&window_label).ok_or("Workspace path not found")?.clone();
         drop(paths);
-        let (ws_uuid_opt, _, _, _) = crate::read_info_json_full(&folder);
+        let (ws_uuid_opt, _, _, _, _) = crate::read_info_json_full(&folder);
         // Guard: workspace must have a UUID in info.json to be valid
         ws_uuid_opt.ok_or("Workspace UUID missing from info.json")?;
         let mgr = state.identity_manager.lock().expect("Mutex poisoned");

--- a/krillnotes-desktop/src-tauri/src/commands/identity.rs
+++ b/krillnotes-desktop/src-tauri/src/commands/identity.rs
@@ -383,9 +383,13 @@ pub fn lock_identity(
 
     use tauri::Manager;
     for label in &labels_to_close {
+        state.closing_windows.lock().expect("Mutex poisoned").insert(label.clone());
         if let Some(win) = app.get_webview_window(label) {
-            let _ = win.close();
+            let _ = win.destroy();
         }
+        state.workspaces.lock().expect("Mutex poisoned").remove(label);
+        state.workspace_paths.lock().expect("Mutex poisoned").remove(label);
+        state.workspace_identities.lock().expect("Mutex poisoned").remove(label);
     }
 
     // Wipe identity from memory.

--- a/krillnotes-desktop/src-tauri/src/commands/workspace.rs
+++ b/krillnotes-desktop/src-tauri/src/commands/workspace.rs
@@ -255,6 +255,7 @@ pub fn rebuild_menus(app: &AppHandle, state: &AppState, lang: &str) -> std::resu
             .insert("macos".to_string(), (result.paste_as_child, result.paste_as_sibling));
         state.workspace_menu_items.lock().expect("Mutex poisoned")
             .insert("macos".to_string(), result.workspace_items);
+        *state.export_menu_item.lock().expect("Mutex poisoned") = Some(result.export_item);
 
         // Re-enable workspace items if any workspace is currently open.
         let any_open = !state.workspace_paths.lock().expect("Mutex poisoned").is_empty();
@@ -266,6 +267,15 @@ pub fn rebuild_menus(app: &AppHandle, state: &AppState, lang: &str) -> std::resu
                 for item in items {
                     let _ = item.set_enabled(true);
                 }
+            }
+            // Toggle export based on focused workspace's ownership.
+            let focused = state.focused_window.lock().expect("Mutex poisoned").clone();
+            let is_owner = focused.and_then(|l| {
+                state.workspaces.lock().expect("Mutex poisoned")
+                    .get(&l).map(|ws| ws.is_owner())
+            }).unwrap_or(false);
+            if let Some(item) = state.export_menu_item.lock().expect("Mutex poisoned").as_ref() {
+                let _ = item.set_enabled(is_owner);
             }
         }
     }
@@ -290,6 +300,9 @@ pub fn rebuild_menus(app: &AppHandle, state: &AppState, lang: &str) -> std::resu
                     item.set_enabled(true)
                         .map_err(|e| format!("Failed to enable menu item: {e}"))?;
                 }
+                let is_owner = state.workspaces.lock().expect("Mutex poisoned")
+                    .get(&label).map(|ws| ws.is_owner()).unwrap_or(false);
+                let _ = result.export_item.set_enabled(is_owner);
             }
 
             window

--- a/krillnotes-desktop/src-tauri/src/commands/workspace.rs
+++ b/krillnotes-desktop/src-tauri/src/commands/workspace.rs
@@ -103,13 +103,13 @@ pub fn handle_file_opened(app: &AppHandle, state: &AppState, path: PathBuf) {
 
 /// Handles opening a `.krillnotes` file from the OS.
 ///
-/// Stores the path in [`AppState::pending_file_open`] for the cold-start
+/// Stores the path in [`AppState::pending_krillnotes_open`] for the cold-start
 /// case (frontend not yet ready), then either emits a `"file-opened"` event
 /// to the existing `"main"` window or creates a new one that will poll
 /// `consume_pending_file_open` on mount.
 fn handle_krillnotes_open(app: &AppHandle, state: &AppState, path: PathBuf) {
     {
-        let mut pending = state.pending_file_open.lock().expect("Mutex poisoned");
+        let mut pending = state.pending_krillnotes_open.lock().expect("Mutex poisoned");
         *pending = Some(path.clone());
     }
 
@@ -126,13 +126,13 @@ fn handle_krillnotes_open(app: &AppHandle, state: &AppState, path: PathBuf) {
 
 /// Handles opening a `.swarm` file from the OS.
 ///
-/// Stores the path in [`AppState::pending_file_open`] for the cold-start
+/// Stores the path in [`AppState::pending_swarm_open`] for the cold-start
 /// case (frontend not yet ready), then emits a `"swarm-file-opened"` event
 /// to the focused window.
 fn handle_swarm_open(app: &AppHandle, state: &AppState, path: PathBuf) {
     // Store path for cold-start retrieval.
     {
-        let mut pending = state.pending_file_open.lock().expect("Mutex poisoned");
+        let mut pending = state.pending_swarm_open.lock().expect("Mutex poisoned");
         *pending = Some(path.clone());
     }
     // Emit to the focused window first; fall back to any open window.
@@ -768,7 +768,7 @@ pub fn get_app_version() -> String {
 #[tauri::command]
 pub fn consume_pending_file_open(state: State<'_, AppState>) -> Option<String> {
     state
-        .pending_file_open
+        .pending_krillnotes_open
         .lock()
         .expect("Mutex poisoned")
         .take()
@@ -782,12 +782,11 @@ pub fn consume_pending_file_open(state: State<'_, AppState>) -> Option<String> {
 #[tauri::command]
 pub fn consume_pending_swarm_file(state: State<'_, AppState>) -> Option<String> {
     state
-        .pending_file_open
+        .pending_swarm_open
         .lock()
         .expect("Mutex poisoned")
         .take()
-        .map(|p| p.to_string_lossy().to_string())
-        .filter(|p| p.ends_with(".swarm"))
+        .map(|p| p.to_string_lossy().into_owned())
 }
 
 // ── Theme commands ────────────────────────────────────────────────
@@ -1073,6 +1072,11 @@ pub fn duplicate_workspace(
     identity_uuid: String,
     new_name: String,
 ) -> std::result::Result<(), String> {
+    let source_folder = PathBuf::from(&source_path);
+    if find_window_for_path(&state, &source_folder).is_some() {
+        return Err("Source workspace is currently open. Close it before duplicating.".to_string());
+    }
+
     let dest_uuid = Uuid::parse_str(&identity_uuid).map_err(|e| e.to_string())?;
     let dest_folder = {
         let mgr = state.identity_manager.lock().expect("Mutex poisoned");
@@ -1084,8 +1088,6 @@ pub fn duplicate_workspace(
     if dest_folder.exists() {
         return Err(format!("A workspace named '{new_name}' already exists."));
     }
-
-    let source_folder = PathBuf::from(&source_path);
     let source_db = source_folder.join("notes.db");
 
     // Decrypt the source DB password via identity.

--- a/krillnotes-desktop/src-tauri/src/commands/workspace.rs
+++ b/krillnotes-desktop/src-tauri/src/commands/workspace.rs
@@ -502,7 +502,7 @@ pub async fn open_workspace(
             let db_path = folder.join("notes.db");
 
             // Read workspace_id from info.json
-            let (ws_uuid_opt, _, _, _) = read_info_json_full(&folder);
+            let (ws_uuid_opt, _, _, _, _) = read_info_json_full(&folder);
             // Guard: workspace must have a UUID to be bound; frontend checks for "IDENTITY_REQUIRED"
             ws_uuid_opt.ok_or_else(|| "IDENTITY_REQUIRED".to_string())?;
 
@@ -636,6 +636,10 @@ pub fn export_workspace_cmd(
     let label = window.label();
     let workspaces = state.workspaces.lock().expect("Mutex poisoned");
     let workspace = workspaces.get(label).ok_or("No workspace open")?;
+
+    if !workspace.is_owner() {
+        return Err("NOT_OWNER".to_string());
+    }
 
     let file = std::fs::File::create(&path).map_err(|e| e.to_string())?;
     krillnotes_core::export_workspace(workspace, file, password.as_deref()).map_err(|e| { log::error!("export_workspace failed: {e}"); e.to_string() })
@@ -913,6 +917,9 @@ pub struct WorkspaceEntry {
     identity_uuid: Option<String>,
     /// Display name of the bound identity, if any and if its file is readable.
     identity_name: Option<String>,
+    /// Whether the bound identity is the workspace owner. `None` for legacy
+    /// workspaces that haven't been opened since the field was added to info.json.
+    is_owner: Option<bool>,
 }
 
 /// Returns the total size in bytes of all files under `dir` (recursive).
@@ -932,22 +939,23 @@ fn dir_size_bytes(dir: &Path) -> u64 {
 }
 
 /// Reads `info.json` from `workspace_dir` and returns all stored fields.
-/// Returns `(None, None, None, None)` if the file is missing or malformed.
-pub fn read_info_json_full(workspace_dir: &Path) -> (Option<String>, Option<i64>, Option<usize>, Option<usize>) {
+/// Returns `(None, None, None, None, None)` if the file is missing or malformed.
+pub fn read_info_json_full(workspace_dir: &Path) -> (Option<String>, Option<i64>, Option<usize>, Option<usize>, Option<bool>) {
     let path = workspace_dir.join("info.json");
     let content = match std::fs::read_to_string(&path) {
         Ok(s) => s,
-        Err(_) => return (None, None, None, None),
+        Err(_) => return (None, None, None, None, None),
     };
     let v: serde_json::Value = match serde_json::from_str(&content) {
         Ok(v) => v,
-        Err(_) => return (None, None, None, None),
+        Err(_) => return (None, None, None, None, None),
     };
     let workspace_id = v["workspace_id"].as_str().map(|s| s.to_string());
     let created_at = v["created_at"].as_i64();
     let note_count = v["note_count"].as_u64().map(|n| n as usize);
     let attachment_count = v["attachment_count"].as_u64().map(|n| n as usize);
-    (workspace_id, created_at, note_count, attachment_count)
+    let is_owner = v["is_owner"].as_bool();
+    (workspace_id, created_at, note_count, attachment_count, is_owner)
 }
 
 /// Lists all workspace folders (subdirectories containing `notes.db`) in the
@@ -1009,7 +1017,7 @@ pub fn list_workspace_files(
                     .map(|t| t.duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_secs() as i64)
                     .unwrap_or(0);
                 let size_bytes = dir_size_bytes(&folder);
-                let (workspace_id, created_at, note_count, attachment_count) =
+                let (workspace_id, created_at, note_count, attachment_count, is_owner) =
                     read_info_json_full(&folder);
 
                 entries.push(WorkspaceEntry {
@@ -1024,6 +1032,7 @@ pub fn list_workspace_files(
                     workspace_uuid: workspace_id,
                     identity_uuid: Some(identity_ref.uuid.to_string()),
                     identity_name: Some(identity_ref.display_name.clone()),
+                    is_owner,
                 });
             }
         }
@@ -1077,6 +1086,11 @@ pub fn duplicate_workspace(
         return Err("Source workspace is currently open. Close it before duplicating.".to_string());
     }
 
+    let (_, _, _, _, is_owner) = read_info_json_full(&source_folder);
+    if is_owner == Some(false) {
+        return Err("NOT_OWNER".to_string());
+    }
+
     let dest_uuid = Uuid::parse_str(&identity_uuid).map_err(|e| e.to_string())?;
     let dest_folder = {
         let mgr = state.identity_manager.lock().expect("Mutex poisoned");
@@ -1093,7 +1107,7 @@ pub fn duplicate_workspace(
     // Decrypt the source DB password via identity.
     // Lock ordering: identity_manager then unlocked_identities, never both held simultaneously.
     let source_password = {
-        let (ws_uuid_opt, _, _, _) = read_info_json_full(&source_folder);
+        let (ws_uuid_opt, _, _, _, _) = read_info_json_full(&source_folder);
         // Guard: source workspace must have a UUID in info.json
         ws_uuid_opt.ok_or_else(|| "Source workspace has no UUID in info.json".to_string())?;
 

--- a/krillnotes-desktop/src-tauri/src/lib.rs
+++ b/krillnotes-desktop/src-tauri/src/lib.rs
@@ -79,10 +79,12 @@ pub struct AppState {
     /// language changes, but items are enabled at build time so the stored handles are
     /// never read back to toggle enabled state.
     pub workspace_menu_items: Arc<Mutex<HashMap<String, Vec<tauri::menu::MenuItem<tauri::Wry>>>>>,
-    /// File path that arrived via OS file-open before the frontend JS was
-    /// ready to receive a pushed event. Cleared on first read by
-    /// `consume_pending_file_open`. `None` when no file is pending.
-    pub pending_file_open: Arc<Mutex<Option<PathBuf>>>,
+    /// `.krillnotes` file path that arrived via OS file-open before the
+    /// frontend was ready. Cleared on first read by `consume_pending_file_open`.
+    pub pending_krillnotes_open: Arc<Mutex<Option<PathBuf>>>,
+    /// `.swarm` file path that arrived via OS file-open before the frontend
+    /// was ready. Cleared on first read by `consume_pending_swarm_file`.
+    pub pending_swarm_open: Arc<Mutex<Option<PathBuf>>>,
     /// Window labels that have been approved for closing by the frontend.
     /// When a label is in this set, the next `CloseRequested` event for
     /// that window is allowed through without interception.
@@ -199,7 +201,8 @@ pub fn run() {
             unlocked_identities: Arc::new(Mutex::new(HashMap::new())),
             paste_menu_items: Arc::new(Mutex::new(HashMap::new())),
             workspace_menu_items: Arc::new(Mutex::new(HashMap::new())),
-            pending_file_open: Arc::new(Mutex::new(None)),
+            pending_krillnotes_open: Arc::new(Mutex::new(None)),
+            pending_swarm_open: Arc::new(Mutex::new(None)),
             closing_windows: Arc::new(Mutex::new(HashSet::new())),
         })
         .on_window_event(|window, event| {

--- a/krillnotes-desktop/src-tauri/src/lib.rs
+++ b/krillnotes-desktop/src-tauri/src/lib.rs
@@ -79,6 +79,9 @@ pub struct AppState {
     /// language changes, but items are enabled at build time so the stored handles are
     /// never read back to toggle enabled state.
     pub workspace_menu_items: Arc<Mutex<HashMap<String, Vec<tauri::menu::MenuItem<tauri::Wry>>>>>,
+    /// Handle to the "Export Workspace" menu item, toggled based on ownership.
+    /// On macOS: stored once at setup. On Windows: stored per-window at open time.
+    pub export_menu_item: Arc<Mutex<Option<tauri::menu::MenuItem<tauri::Wry>>>>,
     /// `.krillnotes` file path that arrived via OS file-open before the
     /// frontend was ready. Cleared on first read by `consume_pending_file_open`.
     pub pending_krillnotes_open: Arc<Mutex<Option<PathBuf>>>,
@@ -201,6 +204,7 @@ pub fn run() {
             unlocked_identities: Arc::new(Mutex::new(HashMap::new())),
             paste_menu_items: Arc::new(Mutex::new(HashMap::new())),
             workspace_menu_items: Arc::new(Mutex::new(HashMap::new())),
+            export_menu_item: Arc::new(Mutex::new(None)),
             pending_krillnotes_open: Arc::new(Mutex::new(None)),
             pending_swarm_open: Arc::new(Mutex::new(None)),
             closing_windows: Arc::new(Mutex::new(HashSet::new())),
@@ -247,13 +251,27 @@ pub fn run() {
                                     let _ = item.set_enabled(false);
                                 }
                             }
+                            if let Some(item) = state.export_menu_item.lock().expect("Mutex poisoned").as_ref() {
+                                let _ = item.set_enabled(false);
+                            }
                         }
                     }
                 }
                 // Track which window is currently active so that menu events
                 // can be routed to the correct window (see handle_menu_event).
                 tauri::WindowEvent::Focused(true) => {
-                    *state.focused_window.lock().expect("Mutex poisoned") = Some(label);
+                    *state.focused_window.lock().expect("Mutex poisoned") = Some(label.clone());
+
+                    // On macOS, update the shared export menu item based on
+                    // whether the focused workspace is owned by the current identity.
+                    #[cfg(target_os = "macos")]
+                    {
+                        let is_owner = state.workspaces.lock().expect("Mutex poisoned")
+                            .get(&label).map(|ws| ws.is_owner()).unwrap_or(false);
+                        if let Some(item) = state.export_menu_item.lock().expect("Mutex poisoned").as_ref() {
+                            let _ = item.set_enabled(is_owner);
+                        }
+                    }
                 }
                 _ => {}
             }
@@ -274,6 +292,7 @@ pub fn run() {
                     .insert("macos".to_string(), (menu_result.paste_as_child, menu_result.paste_as_sibling));
                 state.workspace_menu_items.lock().expect("Mutex poisoned")
                     .insert("macos".to_string(), menu_result.workspace_items);
+                *state.export_menu_item.lock().expect("Mutex poisoned") = Some(menu_result.export_item);
             }
 
             // Ensure home directory exists

--- a/krillnotes-desktop/src-tauri/src/menu.rs
+++ b/krillnotes-desktop/src-tauri/src/menu.rs
@@ -15,6 +15,9 @@ pub struct MenuResult<R: Runtime> {
     pub paste_as_child: MenuItem<R>,
     pub paste_as_sibling: MenuItem<R>,
     pub workspace_items: Vec<MenuItem<R>>,
+    /// Separate handle for the export item so it can be toggled independently
+    /// based on workspace ownership (non-owners cannot export).
+    pub export_item: MenuItem<R>,
 }
 
 struct EditMenuResult<R: Runtime> {
@@ -27,6 +30,7 @@ struct EditMenuResult<R: Runtime> {
 struct FileMenuResult<R: Runtime> {
     submenu: Submenu<R>,
     workspace_items: Vec<MenuItem<R>>,
+    export_item: MenuItem<R>,
 }
 
 struct WorkspaceMenuResult<R: Runtime> {
@@ -61,6 +65,7 @@ pub fn build_menu<R: Runtime>(app: &AppHandle<R>, strings: &Value) -> Result<Men
             paste_as_child: edit_result.paste_as_child,
             paste_as_sibling: edit_result.paste_as_sibling,
             workspace_items,
+            export_item: file_result.export_item,
         });
     }
 
@@ -75,6 +80,7 @@ pub fn build_menu<R: Runtime>(app: &AppHandle<R>, strings: &Value) -> Result<Men
             paste_as_child: edit_result.paste_as_child,
             paste_as_sibling: edit_result.paste_as_sibling,
             workspace_items,
+            export_item: file_result.export_item,
         });
     }
 }
@@ -169,7 +175,8 @@ fn build_file_menu<R: Runtime>(app: &AppHandle<R>, strings: &Value) -> Result<Fi
     let submenu = builder.build()?;
     Ok(FileMenuResult {
         submenu,
-        workspace_items: vec![export_item, sync_now_item],
+        workspace_items: vec![sync_now_item],
+        export_item,
     })
 }
 

--- a/krillnotes-desktop/src/App.tsx
+++ b/krillnotes-desktop/src/App.tsx
@@ -68,6 +68,7 @@ function App() {
   // Global snapshot polling for all unlocked identities (no workspace needed).
   useGlobalSnapshotPolling();
 
+  const [isRootOwner, setIsRootOwner] = useState(false);
   const [sharingIndicatorMode, setSharingIndicatorMode] = useState<'off' | 'auto' | 'on'>('auto');
   const refreshSettings = () => {
     invoke<AppSettings>('get_settings')
@@ -211,12 +212,17 @@ function App() {
       setSwarmFilePath,
     });
 
+  useEffect(() => {
+    if (!workspace) { setIsRootOwner(false); return; }
+    invoke<boolean>('is_root_owner').then(setIsRootOwner).catch(() => setIsRootOwner(false));
+  }, [workspace]);
 
   useMenuEvents(workspace, {
     setShowNewWorkspace, setShowOpenWorkspace, setShowSettings,
     setShowExportPasswordDialog, setShowIdentityManager,
     setShowWorkspacePeers, setShowCreateDeltaDialog,
     statusSetter, proceedWithImport, openSwarmFile,
+    isRootOwner, exportOwnerOnlyMsg: t('workspace.exportOwnerOnly'),
   });
 
   const {

--- a/krillnotes-desktop/src/components/WorkspaceManagerDialog.tsx
+++ b/krillnotes-desktop/src/components/WorkspaceManagerDialog.tsx
@@ -434,8 +434,8 @@ function WorkspaceManagerDialog({ isOpen, onClose, onNewWorkspace }: WorkspaceMa
               </button>
               <button
                 onClick={handleDuplicateBegin}
-                disabled={!selected || isIdentityLocked}
-                title={isIdentityLocked ? t('workspaceManager.unlockToDelete', 'Unlock identity to delete') : undefined}
+                disabled={!selected || isIdentityLocked || selected?.isOwner === false}
+                title={selected?.isOwner === false ? t('workspaceManager.duplicateOwnerOnly') : isIdentityLocked ? t('workspaceManager.unlockToDelete', 'Unlock identity to delete') : undefined}
                 className="px-3 py-1.5 border border-secondary rounded hover:bg-secondary disabled:opacity-50 text-sm"
               >
                 {t('workspaceManager.duplicate')}

--- a/krillnotes-desktop/src/hooks/useMenuEvents.ts
+++ b/krillnotes-desktop/src/hooks/useMenuEvents.ts
@@ -20,6 +20,8 @@ export interface MenuEventCallbacks {
   statusSetter: (msg: string, isError?: boolean) => void;
   proceedWithImport: (zipPath: string, password: string | null) => Promise<void>;
   openSwarmFile: (path: string) => void;
+  isRootOwner: boolean;
+  exportOwnerOnlyMsg: string;
 }
 
 function createMenuHandlers(callbacks: MenuEventCallbacks) {
@@ -34,6 +36,8 @@ function createMenuHandlers(callbacks: MenuEventCallbacks) {
     statusSetter,
     proceedWithImport,
     openSwarmFile,
+    isRootOwner,
+    exportOwnerOnlyMsg,
   } = callbacks;
 
   return {
@@ -47,6 +51,10 @@ function createMenuHandlers(callbacks: MenuEventCallbacks) {
     },
 
     'File > Export Workspace clicked': () => {
+      if (!isRootOwner) {
+        statusSetter(exportOwnerOnlyMsg, true);
+        return;
+      }
       setShowExportPasswordDialog(true);
     },
 

--- a/krillnotes-desktop/src/i18n/locales/de.json
+++ b/krillnotes-desktop/src/i18n/locales/de.json
@@ -153,6 +153,7 @@
     "propertiesSaveFailed": "Arbeitsbereich-Eigenschaften konnten nicht gespeichert werden: {{error}}",
     "exportSuccess": "Arbeitsbereich erfolgreich exportiert",
     "exportFailed": "Export fehlgeschlagen: {{error}}",
+    "exportOwnerOnly": "Nur der Eigentümer des Arbeitsbereichs kann exportieren",
     "importSuccess": "{{noteCount}} Notizen und {{scriptCount}} Skripte importiert",
     "importFailed": "Import fehlgeschlagen: {{error}}",
     "importingProgress": "Importiere {{noteCount}} Notizen und {{scriptCount}} Skripte.",
@@ -331,7 +332,8 @@
     "openingWorkspace": "Wird geöffnet…",
     "duplicateNameRequired": "Bitte gib einen Namen für den duplizierten Arbeitsbereich ein.",
     "duplicatePasswordMismatch": "Die neuen Passwörter stimmen nicht überein.",
-    "duplicateCopyPrefix": "Kopie von {{name}}"
+    "duplicateCopyPrefix": "Kopie von {{name}}",
+    "duplicateOwnerOnly": "Nur der Eigentümer des Arbeitsbereichs kann duplizieren"
   },
   "menu": {
     "file": "Datei",

--- a/krillnotes-desktop/src/i18n/locales/en.json
+++ b/krillnotes-desktop/src/i18n/locales/en.json
@@ -153,6 +153,7 @@
     "propertiesSaveFailed": "Failed to save workspace properties: {{error}}",
     "exportSuccess": "Workspace exported successfully",
     "exportFailed": "Export failed: {{error}}",
+    "exportOwnerOnly": "Only the workspace owner can export",
     "importSuccess": "Imported {{noteCount}} notes and {{scriptCount}} scripts",
     "importFailed": "Import failed: {{error}}",
     "importingProgress": "Importing {{noteCount}} notes and {{scriptCount}} scripts.",
@@ -331,7 +332,8 @@
     "openingWorkspace": "Opening…",
     "duplicateNameRequired": "Please enter a name for the duplicate workspace.",
     "duplicatePasswordMismatch": "New passwords do not match.",
-    "duplicateCopyPrefix": "Copy of {{name}}"
+    "duplicateCopyPrefix": "Copy of {{name}}",
+    "duplicateOwnerOnly": "Only the workspace owner can duplicate"
   },
   "menu": {
     "file": "File",

--- a/krillnotes-desktop/src/i18n/locales/es.json
+++ b/krillnotes-desktop/src/i18n/locales/es.json
@@ -153,6 +153,7 @@
     "propertiesSaveFailed": "Error al guardar las propiedades: {{error}}",
     "exportSuccess": "Espacio de trabajo exportado correctamente",
     "exportFailed": "Error en la exportación: {{error}}",
+    "exportOwnerOnly": "Solo el propietario del espacio de trabajo puede exportar",
     "importSuccess": "{{noteCount}} notas y {{scriptCount}} scripts importados",
     "importFailed": "Error en la importación: {{error}}",
     "importingProgress": "Importando {{noteCount}} notas y {{scriptCount}} scripts.",
@@ -331,7 +332,8 @@
     "openingWorkspace": "Abriendo…",
     "duplicateNameRequired": "Introduce un nombre para el espacio de trabajo duplicado.",
     "duplicatePasswordMismatch": "Las nuevas contraseñas no coinciden.",
-    "duplicateCopyPrefix": "Copia de {{name}}"
+    "duplicateCopyPrefix": "Copia de {{name}}",
+    "duplicateOwnerOnly": "Solo el propietario del espacio de trabajo puede duplicar"
   },
   "menu": {
     "file": "Archivo",

--- a/krillnotes-desktop/src/i18n/locales/fr.json
+++ b/krillnotes-desktop/src/i18n/locales/fr.json
@@ -153,6 +153,7 @@
     "propertiesSaveFailed": "Échec de l'enregistrement des propriétés : {{error}}",
     "exportSuccess": "Espace de travail exporté avec succès",
     "exportFailed": "Échec de l'export : {{error}}",
+    "exportOwnerOnly": "Seul le propriétaire de l'espace de travail peut exporter",
     "importSuccess": "{{noteCount}} notes et {{scriptCount}} scripts importés",
     "importFailed": "Échec de l'import : {{error}}",
     "importingProgress": "Importation de {{noteCount}} notes et {{scriptCount}} scripts.",
@@ -331,7 +332,8 @@
     "openingWorkspace": "Ouverture…",
     "duplicateNameRequired": "Veuillez saisir un nom pour l'espace de travail dupliqué.",
     "duplicatePasswordMismatch": "Les nouveaux mots de passe ne correspondent pas.",
-    "duplicateCopyPrefix": "Copie de {{name}}"
+    "duplicateCopyPrefix": "Copie de {{name}}",
+    "duplicateOwnerOnly": "Seul le propriétaire de l'espace de travail peut dupliquer"
   },
   "menu": {
     "file": "Fichier",

--- a/krillnotes-desktop/src/i18n/locales/ja.json
+++ b/krillnotes-desktop/src/i18n/locales/ja.json
@@ -153,6 +153,7 @@
     "propertiesSaveFailed": "ワークスペースのプロパティの保存に失敗しました: {{error}}",
     "exportSuccess": "ワークスペースを正常にエクスポートしました",
     "exportFailed": "エクスポートに失敗しました: {{error}}",
+    "exportOwnerOnly": "ワークスペースのオーナーのみがエクスポートできます",
     "importSuccess": "{{noteCount}} 件のノートと {{scriptCount}} 件のスクリプトをインポートしました",
     "importFailed": "インポートに失敗しました: {{error}}",
     "importingProgress": "{{noteCount}} 件のノートと {{scriptCount}} 件のスクリプトをインポート中。",
@@ -331,7 +332,8 @@
     "openingWorkspace": "開いています…",
     "duplicateNameRequired": "複製先のワークスペース名を入力してください。",
     "duplicatePasswordMismatch": "新しいパスワードが一致しません。",
-    "duplicateCopyPrefix": "{{name}} のコピー"
+    "duplicateCopyPrefix": "{{name}} のコピー",
+    "duplicateOwnerOnly": "ワークスペースのオーナーのみが複製できます"
   },
   "menu": {
     "file": "ファイル",

--- a/krillnotes-desktop/src/i18n/locales/ko.json
+++ b/krillnotes-desktop/src/i18n/locales/ko.json
@@ -153,6 +153,7 @@
     "propertiesSaveFailed": "작업 공간 속성을 저장하지 못했습니다: {{error}}",
     "exportSuccess": "작업 공간을 성공적으로 내보냈습니다",
     "exportFailed": "내보내기에 실패했습니다: {{error}}",
+    "exportOwnerOnly": "작업 공간 소유자만 내보내기를 할 수 있습니다",
     "importSuccess": "{{noteCount}}개의 노트와 {{scriptCount}}개의 스크립트를 가져왔습니다",
     "importFailed": "가져오기에 실패했습니다: {{error}}",
     "importingProgress": "{{noteCount}}개의 노트와 {{scriptCount}}개의 스크립트를 가져오는 중.",
@@ -331,7 +332,8 @@
     "openingWorkspace": "여는 중…",
     "duplicateNameRequired": "복제할 작업 공간의 이름을 입력하세요.",
     "duplicatePasswordMismatch": "새 비밀번호가 일치하지 않습니다.",
-    "duplicateCopyPrefix": "{{name}}의 사본"
+    "duplicateCopyPrefix": "{{name}}의 사본",
+    "duplicateOwnerOnly": "작업 공간 소유자만 복제할 수 있습니다"
   },
   "menu": {
     "file": "파일",

--- a/krillnotes-desktop/src/i18n/locales/zh.json
+++ b/krillnotes-desktop/src/i18n/locales/zh.json
@@ -153,6 +153,7 @@
     "propertiesSaveFailed": "保存工作区属性失败：{{error}}",
     "exportSuccess": "工作区导出成功",
     "exportFailed": "导出失败：{{error}}",
+    "exportOwnerOnly": "只有工作区所有者才能导出",
     "importSuccess": "已导入 {{noteCount}} 条笔记和 {{scriptCount}} 个脚本",
     "importFailed": "导入失败：{{error}}",
     "importingProgress": "正在导入 {{noteCount}} 条笔记和 {{scriptCount}} 个脚本。",
@@ -331,7 +332,8 @@
     "openingWorkspace": "打开中…",
     "duplicateNameRequired": "请输入副本工作区的名称。",
     "duplicatePasswordMismatch": "新密码不匹配。",
-    "duplicateCopyPrefix": "{{name}} 的副本"
+    "duplicateCopyPrefix": "{{name}} 的副本",
+    "duplicateOwnerOnly": "只有工作区所有者才能复制"
   },
   "menu": {
     "file": "文件",

--- a/krillnotes-desktop/src/types.ts
+++ b/krillnotes-desktop/src/types.ts
@@ -185,6 +185,7 @@ export interface WorkspaceEntry {
   workspaceUuid: string | null;
   identityUuid: string | null;
   identityName: string | null;
+  isOwner?: boolean | null;
 }
 
 export interface WorkspaceMetadata {


### PR DESCRIPTION
## Summary

Fixes four Tauri command issues from Pre-1.0 Audit Batch 5, plus a new guard for shared workspaces:

- **C6+M17:** `lock_identity` now inserts labels into `closing_windows` and calls `destroy()` instead of `close()`, matching the `close_window` pattern. Eagerly removes `workspace_paths`, `workspace_identities`, and `workspaces` entries to prevent stale state.
- **C7:** Split shared `pending_file_open` into `pending_krillnotes_open` and `pending_swarm_open` so rapid `.krillnotes` + `.swarm` opens no longer clobber each other.
- **M18:** `duplicate_workspace` checks `find_window_for_path` at entry and returns an error if the source workspace is currently open.
- **NEW:** Non-owners cannot duplicate or export shared workspaces — duplicate button is disabled, export menu shows an error toast, and backend guards return `NOT_OWNER`. `info.json` now includes `is_owner` for the workspace list to check.

Closes #142

## Test plan

- [ ] Lock identity with 2+ workspaces open — verify both windows close cleanly, no stale state
- [ ] Rapid-open a `.krillnotes` file then a `.swarm` file — verify both consumed
- [ ] Attempt to duplicate a currently-open workspace — verify error message
- [ ] After lock/unlock cycle, verify workspace can be reopened
- [ ] As a non-owner peer, verify Duplicate button is disabled with tooltip
- [ ] As a non-owner peer, verify File > Export shows error toast instead of dialog
- [ ] As workspace owner, verify duplicate and export still work normally