### PR TITLE
fix: frontend cleanup M8-M13 + async forEach fix

### DIFF
--- a/krillnotes-desktop/src/components/FileField.tsx
+++ b/krillnotes-desktop/src/components/FileField.tsx
@@ -46,6 +46,7 @@ export function FileField({
   const { t } = useTranslation();
   const [meta, setMeta] = useState<AttachmentMeta | null>(null);
   const [thumbSrc, setThumbSrc] = useState<string | null>(null);
+  const [fileError, setFileError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!attachmentId || !noteId) { setMeta(null); setThumbSrc(null); return; }
@@ -65,6 +66,7 @@ export function FileField({
   }, [attachmentId, noteId]);
 
   async function handlePick() {
+    setFileError(null);
     // Build extension filters from allowedTypes MIME list.
     // e.g. ["image/png", "image/jpeg"] → extensions: ["png", "jpeg"]
     const filters = allowedTypes.length > 0
@@ -94,7 +96,7 @@ export function FileField({
       // A future orphan sweep can clean these up.
       onValueChange({ File: newMeta.id });
     } catch (err) {
-      alert(t('attachments.failedAttachFile', { error: String(err) }));
+      setFileError(t('attachments.failedAttachFile', { error: String(err) }));
     }
   }
 
@@ -144,6 +146,9 @@ export function FileField({
       >
         {meta ? t('attachments.replaceFile') : t('attachments.chooseFile')}
       </button>
+      {fileError && (
+        <p className="text-xs text-red-500 mt-1">{fileError}</p>
+      )}
     </div>
   );
 }

--- a/krillnotes-desktop/src/components/HoverTooltip.tsx
+++ b/krillnotes-desktop/src/components/HoverTooltip.tsx
@@ -55,26 +55,28 @@ export default function HoverTooltip({
     const container = tooltipRef.current;
     if (!visible || !container || !hoverHtml) return;
     const imgs = Array.from(container.querySelectorAll<HTMLImageElement>('img[data-kn-attach-id]'));
-    imgs.forEach(async (img) => {
-      const attachmentId = img.getAttribute('data-kn-attach-id')!;
-      const widthAttr = img.getAttribute('data-kn-width');
-      try {
-        const result = await invoke<{ data: string; mime_type: string | null }>('get_attachment_data', { attachmentId });
-        const mime = result.mime_type ?? 'image/png';
-        img.src = `data:${mime};base64,${result.data}`;
-        if (widthAttr && parseInt(widthAttr, 10) > 0) {
-          img.style.maxWidth = `${widthAttr}px`;
-          img.style.height = 'auto';
+    Promise.all(
+      imgs.map(async (img) => {
+        const attachmentId = img.getAttribute('data-kn-attach-id')!;
+        const widthAttr = img.getAttribute('data-kn-width');
+        try {
+          const result = await invoke<{ data: string; mime_type: string | null }>('get_attachment_data', { attachmentId });
+          const mime = result.mime_type ?? 'image/png';
+          img.src = `data:${mime};base64,${result.data}`;
+          if (widthAttr && parseInt(widthAttr, 10) > 0) {
+            img.style.maxWidth = `${widthAttr}px`;
+            img.style.height = 'auto';
+          }
+          img.removeAttribute('data-kn-attach-id');
+          img.removeAttribute('data-kn-width');
+        } catch {
+          const span = document.createElement('span');
+          span.className = 'kn-image-error';
+          span.textContent = t('fields.imageNotFound');
+          img.replaceWith(span);
         }
-        img.removeAttribute('data-kn-attach-id');
-        img.removeAttribute('data-kn-width');
-      } catch {
-        const span = document.createElement('span');
-        span.className = 'kn-image-error';
-        span.textContent = t('fields.imageNotFound');
-        img.replaceWith(span);
-      }
-    });
+      })
+    ).catch(err => console.error('Tooltip image hydration error:', err));
   }, [visible, hoverHtml]);
 
   if (!visible) return null;

--- a/krillnotes-desktop/src/components/InfoPanel.tsx
+++ b/krillnotes-desktop/src/components/InfoPanel.tsx
@@ -46,6 +46,7 @@ function InfoPanel({ selectedNote, onNoteUpdated, onDeleteRequest, requestEditMo
   // isEditing is kept in InfoPanel (not in useNoteForm) to break the circular dependency:
   // useSchema needs isEditing, and useNoteForm needs schemaInfo from useSchema.
   const [isEditing, setIsEditing] = useState(false);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const viewHtmlRef = useRef<HTMLDivElement>(null);
   const pendingEditModeRef = useRef(false);
@@ -142,7 +143,7 @@ function InfoPanel({ selectedNote, onNoteUpdated, onDeleteRequest, requestEditMo
         } catch {
           const span = document.createElement('span');
           span.className = 'kn-image-error';
-          span.textContent = 'Image not found';
+          span.textContent = t('fields.imageNotFound');
           img.replaceWith(span);
         }
       })
@@ -179,7 +180,7 @@ function InfoPanel({ selectedNote, onNoteUpdated, onDeleteRequest, requestEditMo
         card.className = 'kn-media-card kn-media-card--instagram';
         const label = document.createElement('span');
         label.className = 'kn-media-card-label';
-        label.textContent = 'Open on Instagram ↗';
+        label.textContent = t('fields.openOnInstagram');
         card.appendChild(label);
       } else {
         return; // unknown type — leave sentinel in place
@@ -372,7 +373,7 @@ function InfoPanel({ selectedNote, onNoteUpdated, onDeleteRequest, requestEditMo
               : 'text-muted-foreground hover:text-foreground'}`}
             onClick={() => setActiveTab('fields')}
           >
-            {t('info_panel.fields', 'Fields')}
+            {t('notes.fields')}
           </button>
         </div>
       )}
@@ -385,6 +386,7 @@ function InfoPanel({ selectedNote, onNoteUpdated, onDeleteRequest, requestEditMo
             ref={viewHtmlRef}
             dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(activeViewHtml, { ADD_ATTR: ['data-note-id', 'data-kn-attach-id', 'data-kn-width', 'data-kn-download-id', 'data-kn-embed-type', 'data-kn-embed-id', 'data-kn-embed-url'], ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp):|data:image\/|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i }) }}
             onClick={(e) => {
+              setDownloadError(null);
               const target = e.target as Element;
 
               const downloadLink = target.closest('[data-kn-download-id]');
@@ -403,7 +405,7 @@ function InfoPanel({ selectedNote, onNoteUpdated, onDeleteRequest, requestEditMo
                     a.click();
                     setTimeout(() => URL.revokeObjectURL(url), 100);
                   })
-                  .catch(err => alert(String(err)));
+                  .catch(err => setDownloadError(String(err)));
                 return;
               }
 
@@ -422,6 +424,10 @@ function InfoPanel({ selectedNote, onNoteUpdated, onDeleteRequest, requestEditMo
               }
             }}
           />
+        )}
+
+        {downloadError && (
+          <p className="text-xs text-red-500 px-1 py-1">{downloadError}</p>
         )}
 
         {/* Tag pills — shown only in view mode */}
@@ -520,7 +526,7 @@ function InfoPanel({ selectedNote, onNoteUpdated, onDeleteRequest, requestEditMo
                   >
                     <ChevronRight size={14} className={`transition-transform ${isCollapsed ? '' : 'rotate-90'}`} />
                     {group.name}
-                    {!isVisible && <span className="text-xs text-muted-foreground ml-2 font-normal">(hidden — data exists)</span>}
+                    {!isVisible && <span className="text-xs text-muted-foreground ml-2 font-normal">{t('fields.hiddenDataExists')}</span>}
                   </button>
                   {!isCollapsed && (
                     <div className="px-4 pb-2 pt-1">
@@ -830,5 +836,12 @@ export default memo(InfoPanel, (prev, next) =>
   prev.requestEditMode === next.requestEditMode &&
   prev.backNoteTitle === next.backNoteTitle &&
   prev.refreshSignal === next.refreshSignal &&
-  prev.effectiveRole === next.effectiveRole,
+  prev.effectiveRole === next.effectiveRole &&
+  prev.onDeleteRequest === next.onDeleteRequest &&
+  prev.onEditDone === next.onEditDone &&
+  prev.onLinkNavigate === next.onLinkNavigate &&
+  prev.onBack === next.onBack &&
+  prev.onShareSubtree === next.onShareSubtree &&
+  prev.onRoleChange === next.onRoleChange &&
+  prev.onRevokeGrant === next.onRevokeGrant,
 );

--- a/krillnotes-desktop/src/components/WorkspaceView.tsx
+++ b/krillnotes-desktop/src/components/WorkspaceView.tsx
@@ -28,7 +28,7 @@ import WorkspacePropertiesDialog from './WorkspacePropertiesDialog';
 import InviteWorkflow from './InviteWorkflow';
 import { ShareDialog } from './ShareDialog';
 import { CascadePreviewDialog } from './CascadePreviewDialog';
-import type { Note, TreeNode, WorkspaceInfo, DeleteResult, SchemaInfo, DropIndicator, SchemaMigratedEvent, ReceivedResponseInfo, CascadeImpactRow, SyncEvent } from '../types';
+import type { Note, TreeNode, WorkspaceInfo, DeleteResult, SchemaInfo, DropIndicator, SchemaMigratedEvent, ReceivedResponseInfo, CascadeImpactRow, SyncEvent, PeerInfo } from '../types';
 import { DeleteStrategy } from '../types';
 import { buildTree, getDescendantIds } from '../utils/tree';
 import { getAvailableTypes, type NotePosition } from '../utils/noteTypes';
@@ -70,6 +70,7 @@ function WorkspaceView({ workspaceInfo, onOpenWorkspacePeers, sharingIndicatorMo
   const [pendingDeleteChildCount, setPendingDeleteChildCount] = useState(0);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   // Incremented to signal InfoPanel to enter edit mode
   const [requestEditMode, setRequestEditMode] = useState(0);
@@ -179,12 +180,12 @@ function WorkspaceView({ workspaceInfo, onOpenWorkspacePeers, sharingIndicatorMo
   // (inviter needs polling to discover accept bundles even before peers exist).
   useEffect(() => {
     Promise.all([
-      invoke<any[]>("list_workspace_peers").catch(e => { console.warn('list_workspace_peers failed:', e); return []; }),
+      invoke<PeerInfo[]>("list_workspace_peers").catch(e => { console.warn('list_workspace_peers failed:', e); return [] as PeerInfo[]; }),
       invoke<boolean>("has_relay_credentials").catch(() => false),
     ]).then(([peers, hasCreds]) => {
-      setHasPeers((peers as any[]).length > 0);
+      setHasPeers(peers.length > 0);
       setHasRelayPeers(
-        (peers as any[]).some((p: any) => p.channelType !== "manual") || (hasCreds as boolean)
+        peers.some(p => p.channelType !== "manual") || hasCreds
       );
     });
   }, []);
@@ -286,6 +287,9 @@ function WorkspaceView({ workspaceInfo, onOpenWorkspacePeers, sharingIndicatorMo
       setIsRootOwner(true);
     }
   };
+
+  const loadPermissionStateRef = useRef(loadPermissionState);
+  loadPermissionStateRef.current = loadPermissionState;
 
   // Tree state — selection, expansion, keyboard navigation, link navigation.
   // Placed after loadNotes because the hook receives loadNotes as a parameter and
@@ -560,20 +564,21 @@ function WorkspaceView({ workspaceInfo, onOpenWorkspacePeers, sharingIndicatorMo
 
   // --- Delete handlers (lifted from InfoPanel) ---
 
-  const handleDeleteRequest = async (noteId: string) => {
+  const handleDeleteRequest = useCallback(async (noteId: string) => {
     try {
       const count = await invoke<number>('count_children', { noteId });
       setPendingDeleteChildCount(count);
       setPendingDeleteId(noteId);
       setShowDeleteDialog(true);
     } catch (err) {
-      alert(t('workspace.failedCheckChildren', { error: String(err) }));
+      setDeleteError(t('workspace.failedCheckChildren', { error: String(err) }));
     }
-  };
+  }, [t]);
 
   const handleDeleteConfirm = async (strategy: DeleteStrategy) => {
     if (!pendingDeleteId || isDeleting) return;
     setIsDeleting(true);
+    setDeleteError(null);
     try {
       await invoke<DeleteResult>('delete_note', {
         noteId: pendingDeleteId,
@@ -584,7 +589,7 @@ function WorkspaceView({ workspaceInfo, onOpenWorkspacePeers, sharingIndicatorMo
       setIsDeleting(false);
       await handleNoteUpdated();
     } catch (err) {
-      alert(t('workspace.failedDelete', { error: String(err) }));
+      setDeleteError(t('workspace.failedDelete', { error: String(err) }));
       setShowDeleteDialog(false);
       setPendingDeleteId(null);
       setIsDeleting(false);
@@ -597,23 +602,21 @@ function WorkspaceView({ workspaceInfo, onOpenWorkspacePeers, sharingIndicatorMo
     setIsDeleting(false);
   };
 
-  const handleEditDone = () => {
+  const handleEditDone = useCallback(() => {
     closePendingUndoGroup();
     requestAnimationFrame(() => {
-      // targets the TreeView container div which carries tabIndex={0}
       treePanelRef.current?.querySelector<HTMLElement>('[tabindex="0"]')?.focus();
     });
-  };
+  }, [closePendingUndoGroup]);
 
   // --- Share/cascade handlers ---
 
-  const handleShareSubtree = (noteId: string) => {
+  const handleShareSubtree = useCallback((noteId: string) => {
     const note = notes.find(n => n.id === noteId);
     setShareScope({ noteId, noteTitle: note?.title ?? noteId });
-  };
+  }, [notes]);
 
-  const handleRoleChange = async (noteId: string, userId: string, newRole: string, oldRole: string) => {
-    // Check for cascade impact first
+  const handleRoleChange = useCallback(async (noteId: string, userId: string, newRole: string, oldRole: string) => {
     try {
       const impacts = await invoke<CascadeImpactRow[]>('preview_cascade', {
         noteId, userId, newRole,
@@ -630,17 +633,16 @@ function WorkspaceView({ workspaceInfo, onOpenWorkspacePeers, sharingIndicatorMo
       }
     } catch { /* no cascade needed */ }
 
-    // No cascade impact — apply directly
     try {
       await invoke('set_permission', { noteId, userId, role: newRole });
-      loadPermissionState();
+      loadPermissionStateRef.current();
       setPermissionRefreshSignal(prev => prev + 1);
     } catch (e) {
       console.error('Failed to change role:', e);
     }
-  };
+  }, [notes]);
 
-  const handleRevokeGrant = async (noteId: string, userId: string) => {
+  const handleRevokeGrant = useCallback(async (noteId: string, userId: string) => {
     try {
       const impacts = await invoke<CascadeImpactRow[]>('preview_cascade', {
         noteId, userId, newRole: 'none',
@@ -659,12 +661,12 @@ function WorkspaceView({ workspaceInfo, onOpenWorkspacePeers, sharingIndicatorMo
 
     try {
       await invoke('revoke_permission', { noteId, userId });
-      loadPermissionState();
+      loadPermissionStateRef.current();
       setPermissionRefreshSignal(prev => prev + 1);
     } catch (e) {
       console.error('Failed to revoke:', e);
     }
-  };
+  }, [notes]);
 
   const handleCascadeConfirm = async (revokeGrants: Array<{ noteId: string; userId: string }>) => {
     if (!cascadeState) return;
@@ -873,6 +875,13 @@ function WorkspaceView({ workspaceInfo, onOpenWorkspacePeers, sharingIndicatorMo
         />
       )}
 
+      {deleteError && (
+        <div className="fixed bottom-4 left-4 bg-red-600 text-white px-4 py-2 rounded-lg shadow-lg text-sm z-50 flex items-center gap-2">
+          <span>{deleteError}</span>
+          <button onClick={() => setDeleteError(null)} className="ml-2 underline text-xs">{t('common.dismiss')}</button>
+        </div>
+      )}
+
       {/* Script Manager Dialog */}
       <ScriptManagerDialog
         isOpen={showScriptManager}
@@ -939,9 +948,9 @@ function WorkspaceView({ workspaceInfo, onOpenWorkspacePeers, sharingIndicatorMo
       {/* Schema migration toasts */}
       {migrationToasts.length > 0 && (
         <div className="fixed bottom-4 right-4 flex flex-col gap-2 z-50">
-          {migrationToasts.map((t, i) => (
+          {migrationToasts.map((toast, i) => (
             <div key={i} className="bg-blue-600 text-white px-4 py-2 rounded-lg shadow-lg text-sm">
-              <strong>"{t.schemaName}" schema updated</strong> — {t.notesMigrated} note{t.notesMigrated !== 1 ? 's' : ''} migrated to version {t.toVersion}
+              {t('workspace.schemaMigrated', { schemaName: toast.schemaName, count: toast.notesMigrated, version: toast.toVersion })}
             </div>
           ))}
         </div>

--- a/krillnotes-desktop/src/hooks/useNoteForm.ts
+++ b/krillnotes-desktop/src/hooks/useNoteForm.ts
@@ -206,7 +206,7 @@ export function useNoteForm(
       // Clear cached HTML so the render_view effect re-fetches.
       setViewHtml({});
     } catch (err) {
-      alert(t('notes.saveFailed', { error: String(err) }));
+      setNoteErrors([t('notes.saveFailed', { error: String(err) })]);
     }
   }, [selectedNote, editedTitle, editedFields, editedTags, previousTab,
       setActiveTab, setPreviousTab, setIsEditing, setIsDirty, setViewHtml,

--- a/krillnotes-desktop/src/i18n/locales/de.json
+++ b/krillnotes-desktop/src/i18n/locales/de.json
@@ -6,6 +6,7 @@
     "close": "Schließen",
     "delete": "Löschen",
     "deleting": "Wird gelöscht…",
+    "dismiss": "Schließen",
     "loading": "Wird geladen…",
     "edit": "Bearbeiten",
     "view": "Ansehen",
@@ -161,7 +162,9 @@
     "failedCheckChildren": "Unterelemente konnten nicht geprüft werden: {{error}}",
     "failedDelete": "Löschen fehlgeschlagen: {{error}}",
     "undoTooltip": "Rückgängig (Cmd+Z)",
-    "redoTooltip": "Wiederholen (Cmd+Umschalt+Z)"
+    "redoTooltip": "Wiederholen (Cmd+Umschalt+Z)",
+    "schemaMigrated_one": "Schema \"{{schemaName}}\" aktualisiert — {{count}} Notiz auf Version {{version}} migriert",
+    "schemaMigrated_other": "Schema \"{{schemaName}}\" aktualisiert — {{count}} Notizen auf Version {{version}} migriert"
   },
   "dialogs": {
     "password": {
@@ -253,7 +256,9 @@
     "starRating_other": "{{count}} Sterne",
     "unknownFieldType": "Unbekannter Feldtyp",
     "imageNotFound": "Bild nicht gefunden",
-    "deleted": "(gelöscht)"
+    "deleted": "(gelöscht)",
+    "hiddenDataExists": "(ausgeblendet — Daten vorhanden)",
+    "openOnInstagram": "Auf Instagram öffnen ↗"
   },
   "tags": {
     "addPlaceholder": "Tag hinzufügen…",

--- a/krillnotes-desktop/src/i18n/locales/en.json
+++ b/krillnotes-desktop/src/i18n/locales/en.json
@@ -6,6 +6,7 @@
     "close": "Close",
     "delete": "Delete",
     "deleting": "Deleting…",
+    "dismiss": "Dismiss",
     "loading": "Loading…",
     "edit": "Edit",
     "view": "View",
@@ -161,7 +162,9 @@
     "failedCheckChildren": "Failed to check children: {{error}}",
     "failedDelete": "Failed to delete: {{error}}",
     "undoTooltip": "Undo (Cmd+Z)",
-    "redoTooltip": "Redo (Cmd+Shift+Z)"
+    "redoTooltip": "Redo (Cmd+Shift+Z)",
+    "schemaMigrated_one": "\"{{schemaName}}\" schema updated — {{count}} note migrated to version {{version}}",
+    "schemaMigrated_other": "\"{{schemaName}}\" schema updated — {{count}} notes migrated to version {{version}}"
   },
   "dialogs": {
     "password": {
@@ -253,7 +256,9 @@
     "starRating_other": "{{count}} stars",
     "unknownFieldType": "Unknown field type",
     "imageNotFound": "Image not found",
-    "deleted": "(deleted)"
+    "deleted": "(deleted)",
+    "hiddenDataExists": "(hidden — data exists)",
+    "openOnInstagram": "Open on Instagram ↗"
   },
   "tags": {
     "addPlaceholder": "Add tag…",

--- a/krillnotes-desktop/src/i18n/locales/es.json
+++ b/krillnotes-desktop/src/i18n/locales/es.json
@@ -6,6 +6,7 @@
     "close": "Cerrar",
     "delete": "Eliminar",
     "deleting": "Eliminando…",
+    "dismiss": "Descartar",
     "loading": "Cargando…",
     "edit": "Editar",
     "view": "Ver",
@@ -161,7 +162,9 @@
     "failedCheckChildren": "Error al comprobar los elementos hijos: {{error}}",
     "failedDelete": "Error al eliminar: {{error}}",
     "undoTooltip": "Deshacer (Cmd+Z)",
-    "redoTooltip": "Rehacer (Cmd+Mayús+Z)"
+    "redoTooltip": "Rehacer (Cmd+Mayús+Z)",
+    "schemaMigrated_one": "Esquema \"{{schemaName}}\" actualizado — {{count}} nota migrada a versión {{version}}",
+    "schemaMigrated_other": "Esquema \"{{schemaName}}\" actualizado — {{count}} notas migradas a versión {{version}}"
   },
   "dialogs": {
     "password": {
@@ -253,7 +256,9 @@
     "starRating_other": "{{count}} estrellas",
     "unknownFieldType": "Tipo de campo desconocido",
     "imageNotFound": "Imagen no encontrada",
-    "deleted": "(eliminado)"
+    "deleted": "(eliminado)",
+    "hiddenDataExists": "(oculto — existen datos)",
+    "openOnInstagram": "Abrir en Instagram ↗"
   },
   "tags": {
     "addPlaceholder": "Añadir etiqueta…",

--- a/krillnotes-desktop/src/i18n/locales/fr.json
+++ b/krillnotes-desktop/src/i18n/locales/fr.json
@@ -6,6 +6,7 @@
     "close": "Fermer",
     "delete": "Supprimer",
     "deleting": "Suppression…",
+    "dismiss": "Fermer",
     "loading": "Chargement…",
     "edit": "Modifier",
     "view": "Afficher",
@@ -161,7 +162,9 @@
     "failedCheckChildren": "Échec de la vérification des enfants : {{error}}",
     "failedDelete": "Échec de la suppression : {{error}}",
     "undoTooltip": "Annuler (Cmd+Z)",
-    "redoTooltip": "Rétablir (Cmd+Maj+Z)"
+    "redoTooltip": "Rétablir (Cmd+Maj+Z)",
+    "schemaMigrated_one": "Schéma \"{{schemaName}}\" mis à jour — {{count}} note migrée vers la version {{version}}",
+    "schemaMigrated_other": "Schéma \"{{schemaName}}\" mis à jour — {{count}} notes migrées vers la version {{version}}"
   },
   "dialogs": {
     "password": {
@@ -253,7 +256,9 @@
     "starRating_other": "{{count}} étoiles",
     "unknownFieldType": "Type de champ inconnu",
     "imageNotFound": "Image introuvable",
-    "deleted": "(supprimé)"
+    "deleted": "(supprimé)",
+    "hiddenDataExists": "(masqué — données présentes)",
+    "openOnInstagram": "Ouvrir sur Instagram ↗"
   },
   "tags": {
     "addPlaceholder": "Ajouter un tag…",

--- a/krillnotes-desktop/src/i18n/locales/ja.json
+++ b/krillnotes-desktop/src/i18n/locales/ja.json
@@ -6,6 +6,7 @@
     "close": "閉じる",
     "delete": "削除",
     "deleting": "削除中…",
+    "dismiss": "閉じる",
     "loading": "読み込み中…",
     "edit": "編集",
     "view": "表示",
@@ -161,7 +162,9 @@
     "failedCheckChildren": "子要素の確認に失敗しました: {{error}}",
     "failedDelete": "削除に失敗しました: {{error}}",
     "undoTooltip": "元に戻す (Cmd+Z)",
-    "redoTooltip": "やり直す (Cmd+Shift+Z)"
+    "redoTooltip": "やり直す (Cmd+Shift+Z)",
+    "schemaMigrated_one": "スキーマ「{{schemaName}}」更新 — {{count}}件のノートをバージョン{{version}}に移行しました",
+    "schemaMigrated_other": "スキーマ「{{schemaName}}」更新 — {{count}}件のノートをバージョン{{version}}に移行しました"
   },
   "dialogs": {
     "password": {
@@ -253,7 +256,9 @@
     "starRating_other": "{{count}} 星",
     "unknownFieldType": "不明なフィールドの種類",
     "imageNotFound": "画像が見つかりません",
-    "deleted": "（削除済み）"
+    "deleted": "（削除済み）",
+    "hiddenDataExists": "(非表示 — データあり)",
+    "openOnInstagram": "Instagramで開く ↗"
   },
   "tags": {
     "addPlaceholder": "タグを追加…",

--- a/krillnotes-desktop/src/i18n/locales/ko.json
+++ b/krillnotes-desktop/src/i18n/locales/ko.json
@@ -6,6 +6,7 @@
     "close": "닫기",
     "delete": "삭제",
     "deleting": "삭제 중…",
+    "dismiss": "닫기",
     "loading": "불러오는 중…",
     "edit": "편집",
     "view": "보기",
@@ -161,7 +162,9 @@
     "failedCheckChildren": "하위 항목을 확인하지 못했습니다: {{error}}",
     "failedDelete": "삭제하지 못했습니다: {{error}}",
     "undoTooltip": "실행 취소 (Cmd+Z)",
-    "redoTooltip": "다시 실행 (Cmd+Shift+Z)"
+    "redoTooltip": "다시 실행 (Cmd+Shift+Z)",
+    "schemaMigrated_one": "스키마 \"{{schemaName}}\" 업데이트 — {{count}}개의 노트가 버전 {{version}}으로 마이그레이션됨",
+    "schemaMigrated_other": "스키마 \"{{schemaName}}\" 업데이트 — {{count}}개의 노트가 버전 {{version}}으로 마이그레이션됨"
   },
   "dialogs": {
     "password": {
@@ -253,7 +256,9 @@
     "starRating_other": "{{count}}점",
     "unknownFieldType": "알 수 없는 필드 유형",
     "imageNotFound": "이미지를 찾을 수 없습니다",
-    "deleted": "(삭제됨)"
+    "deleted": "(삭제됨)",
+    "hiddenDataExists": "(숨김 — 데이터 있음)",
+    "openOnInstagram": "Instagram에서 열기 ↗"
   },
   "tags": {
     "addPlaceholder": "태그 추가…",

--- a/krillnotes-desktop/src/i18n/locales/zh.json
+++ b/krillnotes-desktop/src/i18n/locales/zh.json
@@ -6,6 +6,7 @@
     "close": "关闭",
     "delete": "删除",
     "deleting": "删除中…",
+    "dismiss": "关闭",
     "loading": "加载中…",
     "edit": "编辑",
     "view": "查看",
@@ -161,7 +162,9 @@
     "failedCheckChildren": "检查子项失败：{{error}}",
     "failedDelete": "删除失败：{{error}}",
     "undoTooltip": "撤销 (Cmd+Z)",
-    "redoTooltip": "重做 (Cmd+Shift+Z)"
+    "redoTooltip": "重做 (Cmd+Shift+Z)",
+    "schemaMigrated_one": "模式 \"{{schemaName}}\" 已更新 — {{count}} 个笔记已迁移到版本 {{version}}",
+    "schemaMigrated_other": "模式 \"{{schemaName}}\" 已更新 — {{count}} 个笔记已迁移到版本 {{version}}"
   },
   "dialogs": {
     "password": {
@@ -253,7 +256,9 @@
     "starRating_other": "{{count}} 星",
     "unknownFieldType": "未知字段类型",
     "imageNotFound": "图片未找到",
-    "deleted": "（已删除）"
+    "deleted": "（已删除）",
+    "hiddenDataExists": "(已隐藏 — 数据存在)",
+    "openOnInstagram": "在 Instagram 上打开 ↗"
   },
   "tags": {
     "addPlaceholder": "添加标签…",


### PR DESCRIPTION
## Summary
Closes #143 — Batch 6 (Frontend Cleanup) of the pre-1.0 audit.

- **M8**: Fix shadowed `t()` variable in schema migration toast; use i18n with plural support
- **M9**: Replace non-existent `info_panel.fields` key with existing `notes.fields`; add `common.dismiss` to all 7 locales
- **M10**: Replace 3 DOM-injected English strings (`Image not found`, `Open on Instagram ↗`, `(hidden — data exists)`) with `t()` calls
- **M11**: Replace `invoke<any[]>` with `invoke<PeerInfo[]>` at IPC boundary; remove all `as any[]` casts
- **M12**: Replace all 5 `alert()` calls with inline error state across `WorkspaceView`, `InfoPanel`, `useNoteForm`, and `FileField`
- **M13**: Wrap 5 InfoPanel callback props in `useCallback` (with `loadPermissionStateRef` pattern for stable deps); update memo comparator to include callback identity checks
- **Async fix**: Convert `HoverTooltip` `forEach(async ...)` to `Promise.all(imgs.map(async ...)).catch(...)` so errors surface

5 new i18n keys added to all 7 locale files (`common.dismiss`, `workspace.schemaMigrated_one/_other`, `fields.hiddenDataExists`, `fields.openOnInstagram`).

## Test plan
- [ ] Switch to each of the 7 locales and verify: schema migration toast, fields header, dismiss buttons, image-not-found text, hidden-data-exists indicator, Instagram label
- [ ] Trigger note save/delete/attachment failures — verify inline errors appear, no `alert()` dialogs
- [ ] Open workspace with/without peers — verify peer list renders, no console errors
- [ ] With RBAC peers: select note, add/remove tree nodes, verify InfoPanel callbacks reference correct state
- [ ] Navigate between notes rapidly — verify callbacks fire for correct note
- [ ] Hover over notes with image fields — verify tooltip loads images
- [ ] Hover over notes with broken image refs — verify graceful handling (no console errors)