### PR TITLE
fix: sync timestamps stored as milliseconds instead of seconds (#157)

### DIFF
--- a/krillnotes-core/src/core/workspace/sync.rs
+++ b/krillnotes-core/src/core/workspace/sync.rs
@@ -243,7 +243,7 @@ impl Workspace {
                 created_by, fields, ..
             } => {
                 let fields_json = serde_json::to_string(fields)?;
-                let now_ms = ts.wall_ms as i64;
+                let ts_secs = (ts.wall_ms / 1000) as i64;
                 tx.execute(
                     "INSERT OR IGNORE INTO notes \
                      (id, title, schema, parent_id, position, created_at, modified_at, \
@@ -251,16 +251,16 @@ impl Workspace {
                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 1, 0)",
                     rusqlite::params![
                         note_id, title, schema, parent_id, position,
-                        now_ms, now_ms, created_by, created_by, fields_json,
+                        ts_secs, ts_secs, created_by, created_by, fields_json,
                     ],
                 )?;
             }
 
             Operation::UpdateNote { note_id, title, .. } => {
-                let now_ms = ts.wall_ms as i64;
+                let ts_secs = (ts.wall_ms / 1000) as i64;
                 tx.execute(
                     "UPDATE notes SET title = ?1, modified_at = ?2 WHERE id = ?3",
-                    rusqlite::params![title, now_ms, note_id],
+                    rusqlite::params![title, ts_secs, note_id],
                 )?;
             }
 
@@ -277,10 +277,10 @@ impl Workspace {
                         serde_json::from_str(&json).unwrap_or_default();
                     map.insert(field.clone(), value.clone());
                     let new_json = serde_json::to_string(&map)?;
-                    let now_ms = ts.wall_ms as i64;
+                    let ts_secs = (ts.wall_ms / 1000) as i64;
                     tx.execute(
                         "UPDATE notes SET fields_json = ?1, modified_at = ?2, modified_by = ?3 WHERE id = ?4",
-                        rusqlite::params![new_json, now_ms, modified_by, note_id],
+                        rusqlite::params![new_json, ts_secs, modified_by, note_id],
                     )?;
                 }
             }
@@ -313,10 +313,10 @@ impl Workspace {
             }
 
             Operation::SetChecked { note_id, checked, .. } => {
-                let now_ms = ts.wall_ms as i64;
+                let ts_secs = (ts.wall_ms / 1000) as i64;
                 tx.execute(
                     "UPDATE notes SET is_checked = ?1, modified_at = ?2 WHERE id = ?3",
-                    rusqlite::params![checked, now_ms, note_id],
+                    rusqlite::params![checked, ts_secs, note_id],
                 )?;
             }
 
@@ -324,7 +324,7 @@ impl Workspace {
                 created_by, script_id, name, description, source_code, load_order, enabled, ..
             } => {
                 if created_by == &self.owner_pubkey {
-                    let now_ms = ts.wall_ms as i64;
+                    let ts_secs = (ts.wall_ms / 1000) as i64;
                     tx.execute(
                         "INSERT OR IGNORE INTO user_scripts \
                          (id, name, description, source_code, load_order, enabled, \
@@ -332,7 +332,7 @@ impl Workspace {
                          VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'user')",
                         rusqlite::params![
                             script_id, name, description, source_code,
-                            load_order, *enabled as i32, now_ms, now_ms,
+                            load_order, *enabled as i32, ts_secs, ts_secs,
                         ],
                     )?;
                     scripts_changed = true;
@@ -343,13 +343,13 @@ impl Workspace {
                 modified_by, script_id, name, description, source_code, load_order, enabled, ..
             } => {
                 if modified_by == &self.owner_pubkey {
-                    let now_ms = ts.wall_ms as i64;
+                    let ts_secs = (ts.wall_ms / 1000) as i64;
                     tx.execute(
                         "UPDATE user_scripts SET name = ?1, description = ?2, source_code = ?3, \
                          load_order = ?4, enabled = ?5, modified_at = ?6 WHERE id = ?7",
                         rusqlite::params![
                             name, description, source_code,
-                            load_order, *enabled as i32, now_ms, script_id,
+                            load_order, *enabled as i32, ts_secs, script_id,
                         ],
                     )?;
                     scripts_changed = true;

--- a/krillnotes-core/src/core/workspace/tests.rs
+++ b/krillnotes-core/src/core/workspace/tests.rs
@@ -3868,6 +3868,47 @@ schema("SameVerType", #{
     }
 
     #[test]
+    fn test_apply_incoming_create_note_stores_seconds_timestamp() {
+        use crate::core::hlc::HlcTimestamp;
+
+        let temp = NamedTempFile::new().unwrap();
+        let mut ws = Workspace::create(
+            temp.path(), "", "test-identity",
+            ed25519_dalek::SigningKey::from_bytes(&[1u8; 32]),
+            test_gate(), None,
+        ).unwrap();
+
+        let known_wall_ms: u64 = 1_714_000_000_000; // 2024-04-25 in milliseconds
+        let expected_secs = (known_wall_ms / 1000) as i64;
+
+        let op = Operation::CreateNote {
+            operation_id: "sync-test-op-1".to_string(),
+            timestamp: HlcTimestamp { wall_ms: known_wall_ms, counter: 0, node_id: 99 },
+            device_id: "remote-device".to_string(),
+            note_id: "synced-note-1".to_string(),
+            parent_id: None,
+            position: 0.0,
+            schema: "TextNote".to_string(),
+            title: "Synced Note".to_string(),
+            fields: BTreeMap::new(),
+            created_by: "remote-pubkey".to_string(),
+            signature: String::new(),
+        };
+
+        ws.apply_incoming_operation(op, "remote-peer", &[]).unwrap();
+
+        let row: (i64, i64) = ws.connection().query_row(
+            "SELECT created_at, modified_at FROM notes WHERE id = 'synced-note-1'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        ).unwrap();
+
+        assert_eq!(row.0, expected_secs, "created_at should be seconds ({}), not milliseconds ({})", expected_secs, known_wall_ms);
+        assert_eq!(row.1, expected_secs, "modified_at should be seconds ({}), not milliseconds ({})", expected_secs, known_wall_ms);
+        assert!(row.0 < 10_000_000_000, "created_at looks like milliseconds: {}", row.0);
+    }
+
+    #[test]
     fn test_m6_set_note_checked_stores_seconds_timestamp() {
         let temp = NamedTempFile::new().unwrap();
         let mut ws = Workspace::create(temp.path(), "", "test-identity", ed25519_dalek::SigningKey::from_bytes(&[1u8; 32]), test_gate(), None).unwrap();


### PR DESCRIPTION
## Summary

- **Root cause:** `apply_incoming_operation` in `sync.rs` stored `ts.wall_ms` (milliseconds) directly into `created_at`/`modified_at` columns, while local note creation stores `chrono::Utc::now().timestamp()` (Unix seconds). The frontend expects seconds and multiplies by 1000, so synced notes displayed dates like year 56000+.
- **Fix:** All 6 locations in `sync.rs` that write timestamps to `notes` or `user_scripts` tables now divide `wall_ms` by 1000 before insertion.
- **Regression test:** Added `test_apply_incoming_create_note_stores_seconds_timestamp` that crafts a `CreateNote` op with a known HLC timestamp and asserts the resulting note row stores seconds. Red-green verified.

## Affected operations (sync path only)
| Operation | Column(s) |
|-----------|-----------|
| `CreateNote` | `created_at`, `modified_at` |
| `UpdateNote` | `modified_at` |
| `UpdateField` | `modified_at` |
| `SetChecked` | `modified_at` |
| `CreateUserScript` | `created_at`, `modified_at` |
| `UpdateUserScript` | `modified_at` |

## Test plan
- [x] `cargo test -p krillnotes-core` — 608 tests pass (607 existing + 1 new)
- [x] Red-green cycle: new test fails with old code, passes with fix
- [ ] Manual: sync a note between two peers, verify timestamps match on both sides

Closes #157