### PR TITLE
feat: UnixSecs newtype to prevent timestamp unit mismatch (#157)

### DIFF
--- a/krillnotes-core/src/core/attachment.rs
+++ b/krillnotes-core/src/core/attachment.rs
@@ -13,6 +13,8 @@ use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce, aead::{Aead, KeyInit}};
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 
+use super::timestamp::UnixSecs;
+
 /// Metadata for a single file attachment stored on disk.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -25,7 +27,7 @@ pub struct AttachmentMeta {
     pub hash_sha256: String,
     /// 32-byte HKDF per-file salt (hex-encoded for Tauri serialisation).
     pub salt: String,
-    pub created_at: i64,
+    pub created_at: UnixSecs,
 }
 
 /// Derives a 32-byte workspace attachment key from the master password and a

--- a/krillnotes-core/src/core/export.rs
+++ b/krillnotes-core/src/core/export.rs
@@ -18,6 +18,7 @@ use zip::{ZipArchive, ZipWriter};
 
 use crate::core::attachment::AttachmentMeta;
 use crate::core::note::Note;
+use crate::core::timestamp::UnixSecs;
 use crate::core::user_script;
 use crate::core::workspace::Workspace;
 use crate::get_device_id;
@@ -494,7 +495,7 @@ pub fn import_workspace<R: Read + Seek>(
             .connection_mut()
             .transaction()
             .map_err(|e| ExportError::Database(e.to_string()))?;
-        let now = chrono::Utc::now().timestamp();
+        let now = UnixSecs::now();
         for (source_code, load_order, enabled, category) in &script_sources {
             let id = uuid::Uuid::new_v4().to_string();
             let fm = user_script::parse_front_matter(source_code);

--- a/krillnotes-core/src/core/hlc.rs
+++ b/krillnotes-core/src/core/hlc.rs
@@ -41,6 +41,10 @@ impl HlcTimestamp {
             node_id: 0,
         }
     }
+
+    pub fn to_unix_secs(&self) -> super::timestamp::UnixSecs {
+        super::timestamp::UnixSecs::from_secs((self.wall_ms / 1000) as i64)
+    }
 }
 
 impl Ord for HlcTimestamp {

--- a/krillnotes-core/src/core/mod.rs
+++ b/krillnotes-core/src/core/mod.rs
@@ -30,6 +30,7 @@ pub mod scripting;
 pub mod swarm;
 pub mod storage;
 pub mod sync;
+pub mod timestamp;
 pub mod user_script;
 pub mod undo;
 pub mod workspace;

--- a/krillnotes-core/src/core/note.rs
+++ b/krillnotes-core/src/core/note.rs
@@ -10,6 +10,8 @@ use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
+use super::timestamp::UnixSecs;
+
 /// Custom deserializer for `created_by` / `modified_by` that accepts both
 /// the legacy integer format (always `0`) and the new base64 string format.
 fn deserialize_author_field<'de, D>(deserializer: D) -> Result<String, D::Error>
@@ -72,9 +74,9 @@ pub struct Note {
     /// Fractional sort order among siblings that share the same `parent_id`.
     pub position: f64,
     /// Unix timestamp (seconds) when this note was created.
-    pub created_at: i64,
+    pub created_at: UnixSecs,
     /// Unix timestamp (seconds) of the most recent modification.
-    pub modified_at: i64,
+    pub modified_at: UnixSecs,
     /// Base64-encoded Ed25519 public key of the identity that created this note.
     /// Empty string for notes created before identity enforcement was added.
     #[serde(default, deserialize_with = "deserialize_author_field")]
@@ -114,8 +116,8 @@ mod tests {
             schema: "TextNote".to_string(),
             parent_id: None,
             position: 0.0,
-            created_at: 1234567890,
-            modified_at: 1234567890,
+            created_at: UnixSecs::from_secs(1234567890),
+            modified_at: UnixSecs::from_secs(1234567890),
             created_by: String::new(),
             modified_by: String::new(),
             fields: BTreeMap::new(),
@@ -250,7 +252,7 @@ mod tests {
         // New exports must use "schema", not "nodeType".
         let note = Note {
             id: "x".into(), title: "T".into(), schema: "TextNote".into(),
-            parent_id: None, position: 0.0, created_at: 0, modified_at: 0,
+            parent_id: None, position: 0.0, created_at: UnixSecs::ZERO, modified_at: UnixSecs::ZERO,
             created_by: String::new(), modified_by: String::new(),
             fields: BTreeMap::new(), is_expanded: true, tags: vec![], schema_version: 1,
             is_checked: false,

--- a/krillnotes-core/src/core/scripting/display_helpers.rs
+++ b/krillnotes-core/src/core/scripting/display_helpers.rs
@@ -782,6 +782,7 @@ pub fn render_default_view(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::timestamp::UnixSecs;
     use rhai::Map;
 
     fn make_note_map(id: &str, title: &str) -> Map {
@@ -873,7 +874,7 @@ mod tests {
 
         let note = Note {
             id: "id1".into(), title: "Test".into(), schema: "T".into(),
-            parent_id: None, position: 0.0, created_at: 0, modified_at: 0,
+            parent_id: None, position: 0.0, created_at: UnixSecs::ZERO, modified_at: UnixSecs::ZERO,
             created_by: String::new(), modified_by: String::new(), fields, is_expanded: false, tags: vec![], schema_version: 1, is_checked: false,
         };
         let schema = Schema {
@@ -905,7 +906,7 @@ mod tests {
 
         let note = Note {
             id: "id2".into(), title: "T".into(), schema: "T".into(),
-            parent_id: None, position: 0.0, created_at: 0, modified_at: 0,
+            parent_id: None, position: 0.0, created_at: UnixSecs::ZERO, modified_at: UnixSecs::ZERO,
             created_by: String::new(), modified_by: String::new(), fields, is_expanded: false, tags: vec![], schema_version: 1, is_checked: false,
         };
         let schema = Schema {
@@ -937,7 +938,7 @@ mod tests {
 
         let note = Note {
             id: "id3".into(), title: "T".into(), schema: "T".into(),
-            parent_id: None, position: 0.0, created_at: 0, modified_at: 0,
+            parent_id: None, position: 0.0, created_at: UnixSecs::ZERO, modified_at: UnixSecs::ZERO,
             created_by: String::new(), modified_by: String::new(), fields, is_expanded: false, tags: vec![], schema_version: 1, is_checked: false,
         };
         let schema = Schema {
@@ -972,7 +973,7 @@ mod tests {
 
         let note = Note {
             id: "sec1".into(), title: "T".into(), schema: "T".into(),
-            parent_id: None, position: 0.0, created_at: 0, modified_at: 0,
+            parent_id: None, position: 0.0, created_at: UnixSecs::ZERO, modified_at: UnixSecs::ZERO,
             created_by: String::new(), modified_by: String::new(), fields, is_expanded: false, tags: vec![], schema_version: 1, is_checked: false,
         };
         let schema = Schema {
@@ -1031,7 +1032,7 @@ mod tests {
 
         let note = Note {
             id: "id4".into(), title: "T".into(), schema: "T".into(),
-            parent_id: None, position: 0.0, created_at: 0, modified_at: 0,
+            parent_id: None, position: 0.0, created_at: UnixSecs::ZERO, modified_at: UnixSecs::ZERO,
             created_by: String::new(), modified_by: String::new(), fields, is_expanded: false, tags: vec![], schema_version: 1, is_checked: false,
         };
         let schema = Schema {
@@ -1119,7 +1120,7 @@ mod tests {
             size_bytes: 100,
             hash_sha256: "abc".to_string(),
             salt: "00".repeat(32),
-            created_at: 0,
+            created_at: UnixSecs::ZERO,
         }
     }
 
@@ -1389,7 +1390,7 @@ mod tests {
         );
         let note = Note {
             id: "id-embed".into(), title: "T".into(), schema: "T".into(),
-            parent_id: None, position: 0.0, created_at: 0, modified_at: 0,
+            parent_id: None, position: 0.0, created_at: UnixSecs::ZERO, modified_at: UnixSecs::ZERO,
             created_by: String::new(), modified_by: String::new(), fields, is_expanded: false, tags: vec![], schema_version: 1, is_checked: false,
         };
         let schema = Schema {

--- a/krillnotes-core/src/core/scripting/tests.rs
+++ b/krillnotes-core/src/core/scripting/tests.rs
@@ -1,4 +1,5 @@
     use super::*;
+    use crate::core::timestamp::UnixSecs;
 
     /// Helper: loads the bundled TextNote starter script into a registry.
     fn load_text_note(registry: &mut ScriptRegistry) {
@@ -60,7 +61,7 @@
         let note = Note {
             id: "n1".to_string(), schema: "Folder".to_string(),
             title: "F".to_string(), parent_id: None, position: 0.0,
-            created_at: 0, modified_at: 0, created_by: String::new(), modified_by: String::new(),
+            created_at: UnixSecs::ZERO, modified_at: UnixSecs::ZERO, created_by: String::new(), modified_by: String::new(),
             fields: std::collections::BTreeMap::new(), is_expanded: false, tags: vec![], schema_version: 1, is_checked: false,
         };
         let ctx = QueryContext {
@@ -1059,7 +1060,7 @@
         fields.insert("body".into(), FieldValue::Text("**important**".into()));
         let note = Note {
             id: "n1".into(), title: "Test".into(), schema: "Memo".into(),
-            parent_id: None, position: 0.0, created_at: 0, modified_at: 0,
+            parent_id: None, position: 0.0, created_at: UnixSecs::ZERO, modified_at: UnixSecs::ZERO,
             created_by: String::new(), modified_by: String::new(), fields, is_expanded: false, tags: vec![], schema_version: 1, is_checked: false,
         };
 
@@ -1104,8 +1105,8 @@
             title: "Test".to_string(),
             parent_id: None,
             position: 0.0,
-            created_at: 0,
-            modified_at: 0,
+            created_at: UnixSecs::ZERO,
+            modified_at: UnixSecs::ZERO,
             created_by: String::new(),
             modified_by: String::new(),
             fields: BTreeMap::new(),
@@ -1408,7 +1409,7 @@
         let note = Note {
             id: "n1".to_string(), schema: "BoomView".to_string(),
             title: "T".to_string(), parent_id: None, position: 0.0,
-            created_at: 0, modified_at: 0, created_by: String::new(), modified_by: String::new(),
+            created_at: UnixSecs::ZERO, modified_at: UnixSecs::ZERO, created_by: String::new(), modified_by: String::new(),
             fields: BTreeMap::new(), is_expanded: false, tags: vec![], schema_version: 1, is_checked: false,
         };
         let ctx = QueryContext {
@@ -1471,7 +1472,7 @@
             id: "n1".into(), title: "Hello".into(),
             schema: "TextNote".into(), parent_id: None,
             fields: std::collections::BTreeMap::new(), position: 0.0,
-            created_at: 0, modified_at: 0, created_by: String::new(), modified_by: String::new(),
+            created_at: UnixSecs::ZERO, modified_at: UnixSecs::ZERO, created_by: String::new(), modified_by: String::new(),
             is_expanded: false, tags: vec![], schema_version: 1, is_checked: false,
         };
         let ctx = QueryContext {
@@ -1498,7 +1499,7 @@
             id: "p1".into(), title: "Parent".into(),
             schema: "TextNote".into(), parent_id: None,
             fields: std::collections::BTreeMap::new(), position: 0.0,
-            created_at: 0, modified_at: 0, created_by: String::new(), modified_by: String::new(),
+            created_at: UnixSecs::ZERO, modified_at: UnixSecs::ZERO, created_by: String::new(), modified_by: String::new(),
             is_expanded: false, tags: vec![], schema_version: 1, is_checked: false,
         };
         let ctx = QueryContext {
@@ -1520,7 +1521,7 @@
             id: "n1".into(), title: "T".into(),
             schema: "TextNote".into(), parent_id: None,
             fields: std::collections::BTreeMap::new(), position: 0.0,
-            created_at: 0, modified_at: 0, created_by: String::new(), modified_by: String::new(),
+            created_at: UnixSecs::ZERO, modified_at: UnixSecs::ZERO, created_by: String::new(), modified_by: String::new(),
             is_expanded: false, tags: vec![], schema_version: 1, is_checked: false,
         };
         let ctx = QueryContext {
@@ -1547,7 +1548,7 @@
             id: "n1".into(), title: "T".into(),
             schema: "TextNote".into(), parent_id: None,
             fields: std::collections::BTreeMap::new(), position: 0.0,
-            created_at: 0, modified_at: 0, created_by: String::new(), modified_by: String::new(),
+            created_at: UnixSecs::ZERO, modified_at: UnixSecs::ZERO, created_by: String::new(), modified_by: String::new(),
             is_expanded: false, tags: vec![], schema_version: 1, is_checked: false,
         };
         let ctx = QueryContext {
@@ -1569,7 +1570,7 @@
             id: id.into(), title: "Test".into(),
             schema: node_type.into(), parent_id: None,
             fields: Default::default(), position: 0.0,
-            created_at: 0, modified_at: 0, created_by: String::new(), modified_by: String::new(),
+            created_at: UnixSecs::ZERO, modified_at: UnixSecs::ZERO, created_by: String::new(), modified_by: String::new(),
             is_expanded: false, tags: vec![], schema_version: 1, is_checked: false,
         }
     }
@@ -1737,7 +1738,7 @@
         let note = Note {
             id: "n1".to_string(), schema: "Tagged".to_string(),
             title: "T".to_string(), parent_id: None, position: 0.0,
-            created_at: 0, modified_at: 0, created_by: String::new(), modified_by: String::new(),
+            created_at: UnixSecs::ZERO, modified_at: UnixSecs::ZERO, created_by: String::new(), modified_by: String::new(),
             fields: std::collections::BTreeMap::new(), is_expanded: false,
             tags: vec!["rust".to_string(), "notes".to_string()], schema_version: 1, is_checked: false,
         };
@@ -1936,7 +1937,7 @@
         registry.resolve_bindings();
         let note = crate::Note {
             id: "id1".into(), title: "Test Note".into(), schema: "HoverRun".into(),
-            parent_id: None, position: 0.0, created_at: 0, modified_at: 0,
+            parent_id: None, position: 0.0, created_at: UnixSecs::ZERO, modified_at: UnixSecs::ZERO,
             created_by: String::new(), modified_by: String::new(),
             fields: std::collections::BTreeMap::new(), is_expanded: false, tags: vec![], schema_version: 1, is_checked: false,
         };
@@ -2002,7 +2003,7 @@
                 size_bytes: 100,
                 hash_sha256: "abc".to_string(),
                 salt: "00".repeat(32),
-                created_at: 0,
+                created_at: UnixSecs::ZERO,
             }],
         );
 
@@ -2033,7 +2034,7 @@
         let note = Note {
             id: "n1".to_string(), schema: "PhotoNote".to_string(),
             title: "T".to_string(), parent_id: None, fields, tags: vec![], schema_version: 1,
-            created_at: 0, modified_at: 0, position: 0.0,
+            created_at: UnixSecs::ZERO, modified_at: UnixSecs::ZERO, position: 0.0,
             created_by: String::new(), modified_by: String::new(), is_expanded: false, is_checked: false,
         };
 
@@ -2064,7 +2065,7 @@
         let note = Note {
             id: "n2".to_string(), schema: "PhotoNote".to_string(),
             title: "T".to_string(), parent_id: None, fields, tags: vec![], schema_version: 1,
-            created_at: 0, modified_at: 0, position: 0.0,
+            created_at: UnixSecs::ZERO, modified_at: UnixSecs::ZERO, position: 0.0,
             created_by: String::new(), modified_by: String::new(), is_expanded: false, is_checked: false,
         };
 

--- a/krillnotes-core/src/core/timestamp.rs
+++ b/krillnotes-core/src/core/timestamp.rs
@@ -1,0 +1,40 @@
+use rusqlite::types::{FromSql, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct UnixSecs(i64);
+
+impl UnixSecs {
+    pub const ZERO: Self = Self(0);
+
+    pub fn now() -> Self {
+        Self(chrono::Utc::now().timestamp())
+    }
+
+    pub fn from_secs(secs: i64) -> Self {
+        Self(secs)
+    }
+
+    pub fn as_i64(self) -> i64 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for UnixSecs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl ToSql for UnixSecs {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
+        self.0.to_sql()
+    }
+}
+
+impl FromSql for UnixSecs {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        i64::column_result(value).map(Self)
+    }
+}

--- a/krillnotes-core/src/core/user_script.rs
+++ b/krillnotes-core/src/core/user_script.rs
@@ -8,6 +8,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use super::timestamp::UnixSecs;
+
 /// A user-defined Rhai script stored in the workspace database.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -18,8 +20,8 @@ pub struct UserScript {
     pub source_code: String,
     pub load_order: i32,
     pub enabled: bool,
-    pub created_at: i64,
-    pub modified_at: i64,
+    pub created_at: UnixSecs,
+    pub modified_at: UnixSecs,
     pub category: String, // "schema" or "library"
 }
 
@@ -110,8 +112,8 @@ schema("Test", #{ fields: [] });
             source_code: "".to_string(),
             load_order: 0,
             enabled: true,
-            created_at: 0,
-            modified_at: 0,
+            created_at: UnixSecs::ZERO,
+            modified_at: UnixSecs::ZERO,
             category: "schema".to_string(),
         };
         assert_eq!(script.category, "schema");

--- a/krillnotes-core/src/core/workspace/attachments.rs
+++ b/krillnotes-core/src/core/workspace/attachments.rs
@@ -45,7 +45,7 @@ impl Workspace {
         };
 
         let id = uuid::Uuid::new_v4().to_string();
-        let now = chrono::Utc::now().timestamp();
+        let now = UnixSecs::now();
 
         let (encrypted_bytes, file_salt) =
             encrypt_attachment(data, self.attachment_key.as_ref())?;
@@ -132,7 +132,7 @@ impl Workspace {
             h.update(data);
             format!("{:x}", h.finalize())
         };
-        let now = chrono::Utc::now().timestamp();
+        let now = UnixSecs::now();
         let (encrypted_bytes, file_salt) = encrypt_attachment(data, self.attachment_key.as_ref())?;
         let enc_path = self.workspace_root.join("attachments").join(format!("{id}.enc"));
         std::fs::write(&enc_path, &encrypted_bytes)?;

--- a/krillnotes-core/src/core/workspace/hooks.rs
+++ b/krillnotes-core/src/core/workspace/hooks.rs
@@ -288,7 +288,7 @@ impl Workspace {
         let pending_notes: Vec<_> = existing_updates.into_iter().chain(ordered_creates).collect();
 
         if !pending_notes.is_empty() {
-            let now = chrono::Utc::now().timestamp();
+            let now = UnixSecs::now();
 
             // Pre-advance HLC for each pending note before borrowing self.storage.
             // Creates need one timestamp; updates need one for title + one per field + optional checked.

--- a/krillnotes-core/src/core/workspace/mod.rs
+++ b/krillnotes-core/src/core/workspace/mod.rs
@@ -18,7 +18,7 @@ use crate::core::user_script;
 use crate::{
     DeleteResult, DeleteStrategy, FieldValue, KrillnotesError, Note,
     Operation, OperationLog, PurgeStrategy, QueryContext, Result, RetractInverse, SaveResult,
-    ScriptError, ScriptRegistry, Storage, UndoResult, UserScript,
+    ScriptError, ScriptRegistry, Storage, UndoResult, UnixSecs, UserScript,
 };
 use rhai::Dynamic;
 use rusqlite::{Connection, OptionalExtension};
@@ -187,7 +187,7 @@ impl Workspace {
             None
         };
 
-        let now = chrono::Utc::now().timestamp();
+        let now = UnixSecs::now();
         if config.seed_starter_scripts {
             let starters = ScriptRegistry::starter_scripts();
             let tx = storage.connection_mut().transaction()?;
@@ -720,7 +720,7 @@ impl Workspace {
                 [],
                 |row| row.get(0),
             )
-            .unwrap_or_else(|_| chrono::Utc::now().timestamp());
+            .unwrap_or_else(|_| UnixSecs::now().as_i64());
 
         let info = serde_json::json!({
             "workspace_id": self.workspace_id,
@@ -1089,7 +1089,7 @@ fn sync_note_links(tx: &rusqlite::Transaction, note_id: &str, fields: &BTreeMap<
 ///
 /// `position` is stored as REAL in the DB (to support fractional positions for future
 /// CRDT ordering) but the Rust API still uses `i32`; we read it as `f64` and truncate.
-type NoteRow = (String, String, String, Option<String>, f64, i64, i64, String, String, String, i64, u32, bool, Option<String>);
+type NoteRow = (String, String, String, Option<String>, f64, UnixSecs, UnixSecs, String, String, String, i64, u32, bool, Option<String>);
 
 /// Row-mapping closure for `rusqlite::Row` → raw tuple.
 ///
@@ -1102,8 +1102,8 @@ fn map_note_row(row: &rusqlite::Row) -> rusqlite::Result<NoteRow> {
         row.get::<_, String>(2)?,           // schema
         row.get::<_, Option<String>>(3)?,   // parent_id
         row.get::<_, f64>(4)?,              // position
-        row.get::<_, i64>(5)?,              // created_at
-        row.get::<_, i64>(6)?,              // modified_at
+        row.get::<_, UnixSecs>(5)?,         // created_at
+        row.get::<_, UnixSecs>(6)?,         // modified_at
         row.get::<_, String>(7).unwrap_or_default(),  // created_by
         row.get::<_, String>(8).unwrap_or_default(),  // modified_by
         row.get::<_, String>(9)?,           // fields_json

--- a/krillnotes-core/src/core/workspace/notes.rs
+++ b/krillnotes-core/src/core/workspace/notes.rs
@@ -103,7 +103,7 @@ impl Workspace {
             None
         };
 
-        let now = chrono::Utc::now().timestamp();
+        let now = UnixSecs::now();
         let mut note = Note {
             id: Uuid::new_v4().to_string(),
             title: "Untitled".to_string(),
@@ -180,7 +180,7 @@ impl Workspace {
                 &parent_note.id, &parent_note.schema, &parent_note.title, &parent_note.fields,
                 &note.id, &note.schema, &note.title, &note.fields,
             )? {
-                let now = chrono::Utc::now().timestamp();
+                let now = UnixSecs::now();
                 if let Some((new_title, new_fields)) = hook_result.child {
                     let fields_json = serde_json::to_string(&new_fields)?;
                     tx.execute(
@@ -346,7 +346,7 @@ impl Workspace {
         };
         self.authorize(&auth_op)?;
 
-        let now = chrono::Utc::now().timestamp();
+        let now = UnixSecs::now();
 
         // Pre-advance HLC once per note in the subtree, and capture signing key,
         // before the transaction borrows self.storage mutably.
@@ -438,7 +438,7 @@ impl Workspace {
     /// Returns [`crate::KrillnotesError::SchemaNotFound`] if `node_type` is unknown,
     /// or [`crate::KrillnotesError::Database`] for any SQLite failure.
     pub fn create_note_root(&mut self, node_type: &str) -> Result<String> {
-        let now = chrono::Utc::now().timestamp();
+        let now = UnixSecs::now();
         let schema = self.script_registry.get_schema(node_type)?;
 
         // Validate allowed_parent_schemas — root notes have no parent
@@ -560,7 +560,7 @@ impl Workspace {
         };
         self.authorize(&auth_op)?;
 
-        let now = chrono::Utc::now().timestamp();
+        let now = UnixSecs::now();
         let ts = self.advance_hlc();
         let signing_key = self.signing_key.clone();
         let tx = self.storage.connection_mut().transaction()?;
@@ -887,7 +887,7 @@ impl Workspace {
         };
         self.authorize(&auth_op)?;
 
-        let now = chrono::Utc::now().timestamp();
+        let now = UnixSecs::now();
         let ts = self.advance_hlc();
         let signing_key = self.signing_key.clone();
 
@@ -1131,7 +1131,7 @@ impl Workspace {
         };
         self.authorize(&auth_op)?;
 
-        let now = chrono::Utc::now().timestamp();
+        let now = UnixSecs::now();
         let ts = self.advance_hlc();
         let signing_key = self.signing_key.clone();
         let tx = self.storage.connection_mut().transaction()?;
@@ -1163,7 +1163,7 @@ impl Workspace {
                 &parent_note.id, &parent_note.schema, &parent_note.title, &parent_note.fields,
                 &note_to_move.id, &note_to_move.schema, &note_to_move.title, &note_to_move.fields,
             )? {
-                let hook_now = chrono::Utc::now().timestamp();
+                let hook_now = UnixSecs::now();
                 if let Some((new_title, new_fields)) = hook_result.child {
                     let fields_json = serde_json::to_string(&new_fields)?;
                     tx.execute(
@@ -1767,7 +1767,7 @@ impl Workspace {
         let schema = self.script_registry.get_schema(&note_schema)?;
         schema.validate_required_fields(&fields)?;
 
-        let now = chrono::Utc::now().timestamp();
+        let now = UnixSecs::now();
         let fields_json = serde_json::to_string(&fields)?;
 
         // Clean up replaced or cleared File field attachments before the note UPDATE.

--- a/krillnotes-core/src/core/workspace/scripts.rs
+++ b/krillnotes-core/src/core/workspace/scripts.rs
@@ -102,7 +102,7 @@ impl Workspace {
             ));
         }
 
-        let now = chrono::Utc::now().timestamp();
+        let now = UnixSecs::now();
         let id = Uuid::new_v4().to_string();
 
         // Pre-validation
@@ -209,7 +209,7 @@ impl Workspace {
         // Capture old script state BEFORE the update for undo.
         let old_script = self.get_user_script(script_id)?;
 
-        let now = chrono::Utc::now().timestamp();
+        let now = UnixSecs::now();
         // Advance HLC and capture signing key before the transaction borrows self.storage.
         let ts = self.advance_hlc();
         let signing_key = self.signing_key.clone();

--- a/krillnotes-core/src/core/workspace/sync.rs
+++ b/krillnotes-core/src/core/workspace/sync.rs
@@ -243,7 +243,7 @@ impl Workspace {
                 created_by, fields, ..
             } => {
                 let fields_json = serde_json::to_string(fields)?;
-                let now_ms = ts.wall_ms as i64;
+                let ts_secs = (ts.wall_ms / 1000) as i64;
                 tx.execute(
                     "INSERT OR IGNORE INTO notes \
                      (id, title, schema, parent_id, position, created_at, modified_at, \
@@ -251,16 +251,16 @@ impl Workspace {
                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 1, 0)",
                     rusqlite::params![
                         note_id, title, schema, parent_id, position,
-                        now_ms, now_ms, created_by, created_by, fields_json,
+                        ts_secs, ts_secs, created_by, created_by, fields_json,
                     ],
                 )?;
             }
 
             Operation::UpdateNote { note_id, title, .. } => {
-                let now_ms = ts.wall_ms as i64;
+                let ts_secs = (ts.wall_ms / 1000) as i64;
                 tx.execute(
                     "UPDATE notes SET title = ?1, modified_at = ?2 WHERE id = ?3",
-                    rusqlite::params![title, now_ms, note_id],
+                    rusqlite::params![title, ts_secs, note_id],
                 )?;
             }
 
@@ -277,10 +277,10 @@ impl Workspace {
                         serde_json::from_str(&json).unwrap_or_default();
                     map.insert(field.clone(), value.clone());
                     let new_json = serde_json::to_string(&map)?;
-                    let now_ms = ts.wall_ms as i64;
+                    let ts_secs = (ts.wall_ms / 1000) as i64;
                     tx.execute(
                         "UPDATE notes SET fields_json = ?1, modified_at = ?2, modified_by = ?3 WHERE id = ?4",
-                        rusqlite::params![new_json, now_ms, modified_by, note_id],
+                        rusqlite::params![new_json, ts_secs, modified_by, note_id],
                     )?;
                 }
             }
@@ -313,10 +313,10 @@ impl Workspace {
             }
 
             Operation::SetChecked { note_id, checked, .. } => {
-                let now_ms = ts.wall_ms as i64;
+                let ts_secs = (ts.wall_ms / 1000) as i64;
                 tx.execute(
                     "UPDATE notes SET is_checked = ?1, modified_at = ?2 WHERE id = ?3",
-                    rusqlite::params![checked, now_ms, note_id],
+                    rusqlite::params![checked, ts_secs, note_id],
                 )?;
             }
 
@@ -324,7 +324,7 @@ impl Workspace {
                 created_by, script_id, name, description, source_code, load_order, enabled, ..
             } => {
                 if created_by == &self.owner_pubkey {
-                    let now_ms = ts.wall_ms as i64;
+                    let ts_secs = (ts.wall_ms / 1000) as i64;
                     tx.execute(
                         "INSERT OR IGNORE INTO user_scripts \
                          (id, name, description, source_code, load_order, enabled, \
@@ -332,7 +332,7 @@ impl Workspace {
                          VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'user')",
                         rusqlite::params![
                             script_id, name, description, source_code,
-                            load_order, *enabled as i32, now_ms, now_ms,
+                            load_order, *enabled as i32, ts_secs, ts_secs,
                         ],
                     )?;
                     scripts_changed = true;
@@ -343,13 +343,13 @@ impl Workspace {
                 modified_by, script_id, name, description, source_code, load_order, enabled, ..
             } => {
                 if modified_by == &self.owner_pubkey {
-                    let now_ms = ts.wall_ms as i64;
+                    let ts_secs = (ts.wall_ms / 1000) as i64;
                     tx.execute(
                         "UPDATE user_scripts SET name = ?1, description = ?2, source_code = ?3, \
                          load_order = ?4, enabled = ?5, modified_at = ?6 WHERE id = ?7",
                         rusqlite::params![
                             name, description, source_code,
-                            load_order, *enabled as i32, now_ms, script_id,
+                            load_order, *enabled as i32, ts_secs, script_id,
                         ],
                     )?;
                     scripts_changed = true;

--- a/krillnotes-core/src/core/workspace/sync.rs
+++ b/krillnotes-core/src/core/workspace/sync.rs
@@ -243,7 +243,7 @@ impl Workspace {
                 created_by, fields, ..
             } => {
                 let fields_json = serde_json::to_string(fields)?;
-                let ts_secs = (ts.wall_ms / 1000) as i64;
+                let ts_secs = ts.to_unix_secs();
                 tx.execute(
                     "INSERT OR IGNORE INTO notes \
                      (id, title, schema, parent_id, position, created_at, modified_at, \
@@ -257,7 +257,7 @@ impl Workspace {
             }
 
             Operation::UpdateNote { note_id, title, .. } => {
-                let ts_secs = (ts.wall_ms / 1000) as i64;
+                let ts_secs = ts.to_unix_secs();
                 tx.execute(
                     "UPDATE notes SET title = ?1, modified_at = ?2 WHERE id = ?3",
                     rusqlite::params![title, ts_secs, note_id],
@@ -277,7 +277,7 @@ impl Workspace {
                         serde_json::from_str(&json).unwrap_or_default();
                     map.insert(field.clone(), value.clone());
                     let new_json = serde_json::to_string(&map)?;
-                    let ts_secs = (ts.wall_ms / 1000) as i64;
+                    let ts_secs = ts.to_unix_secs();
                     tx.execute(
                         "UPDATE notes SET fields_json = ?1, modified_at = ?2, modified_by = ?3 WHERE id = ?4",
                         rusqlite::params![new_json, ts_secs, modified_by, note_id],
@@ -313,7 +313,7 @@ impl Workspace {
             }
 
             Operation::SetChecked { note_id, checked, .. } => {
-                let ts_secs = (ts.wall_ms / 1000) as i64;
+                let ts_secs = ts.to_unix_secs();
                 tx.execute(
                     "UPDATE notes SET is_checked = ?1, modified_at = ?2 WHERE id = ?3",
                     rusqlite::params![checked, ts_secs, note_id],
@@ -324,7 +324,7 @@ impl Workspace {
                 created_by, script_id, name, description, source_code, load_order, enabled, ..
             } => {
                 if created_by == &self.owner_pubkey {
-                    let ts_secs = (ts.wall_ms / 1000) as i64;
+                    let ts_secs = ts.to_unix_secs();
                     tx.execute(
                         "INSERT OR IGNORE INTO user_scripts \
                          (id, name, description, source_code, load_order, enabled, \
@@ -343,7 +343,7 @@ impl Workspace {
                 modified_by, script_id, name, description, source_code, load_order, enabled, ..
             } => {
                 if modified_by == &self.owner_pubkey {
-                    let ts_secs = (ts.wall_ms / 1000) as i64;
+                    let ts_secs = ts.to_unix_secs();
                     tx.execute(
                         "UPDATE user_scripts SET name = ?1, description = ?2, source_code = ?3, \
                          load_order = ?4, enabled = ?5, modified_at = ?6 WHERE id = ?7",

--- a/krillnotes-core/src/core/workspace/tests.rs
+++ b/krillnotes-core/src/core/workspace/tests.rs
@@ -3868,6 +3868,47 @@ schema("SameVerType", #{
     }
 
     #[test]
+    fn test_apply_incoming_create_note_stores_seconds_timestamp() {
+        use crate::core::hlc::HlcTimestamp;
+
+        let temp = NamedTempFile::new().unwrap();
+        let mut ws = Workspace::create(
+            temp.path(), "", "test-identity",
+            ed25519_dalek::SigningKey::from_bytes(&[1u8; 32]),
+            test_gate(), None,
+        ).unwrap();
+
+        let known_wall_ms: u64 = 1_714_000_000_000; // 2024-04-25 in milliseconds
+        let expected_secs = (known_wall_ms / 1000) as i64;
+
+        let op = Operation::CreateNote {
+            operation_id: "sync-test-op-1".to_string(),
+            timestamp: HlcTimestamp { wall_ms: known_wall_ms, counter: 0, node_id: 99 },
+            device_id: "remote-device".to_string(),
+            note_id: "synced-note-1".to_string(),
+            parent_id: None,
+            position: 0.0,
+            schema: "TextNote".to_string(),
+            title: "Synced Note".to_string(),
+            fields: BTreeMap::new(),
+            created_by: "remote-pubkey".to_string(),
+            signature: String::new(),
+        };
+
+        ws.apply_incoming_operation(op, "remote-peer", &[]).unwrap();
+
+        let row: (i64, i64) = ws.connection().query_row(
+            "SELECT created_at, modified_at FROM notes WHERE id = 'synced-note-1'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        ).unwrap();
+
+        assert_eq!(row.0, expected_secs, "created_at should be seconds ({}), not milliseconds ({})", expected_secs, known_wall_ms);
+        assert_eq!(row.1, expected_secs, "modified_at should be seconds ({}), not milliseconds ({})", expected_secs, known_wall_ms);
+        assert!(row.0 < 10_000_000_000, "created_at looks like milliseconds: {}", row.0);
+    }
+
+    #[test]
     fn test_m6_set_note_checked_stores_seconds_timestamp() {
         let temp = NamedTempFile::new().unwrap();
         let mut ws = Workspace::create(temp.path(), "", "test-identity", ed25519_dalek::SigningKey::from_bytes(&[1u8; 32]), test_gate(), None).unwrap();

--- a/krillnotes-core/src/core/workspace/tests.rs
+++ b/krillnotes-core/src/core/workspace/tests.rs
@@ -3920,7 +3920,7 @@ schema("SameVerType", #{
         // A seconds-range timestamp (10 digits) is < 10_000_000_000.
         // A milliseconds-range timestamp (13 digits) is > 1_000_000_000_000.
         assert!(
-            note.modified_at < 10_000_000_000,
+            note.modified_at < UnixSecs::from_secs(10_000_000_000),
             "modified_at should be seconds, not milliseconds: got {}",
             note.modified_at
         );

--- a/krillnotes-core/src/core/workspace/undo.rs
+++ b/krillnotes-core/src/core/workspace/undo.rs
@@ -503,7 +503,7 @@ impl Workspace {
                 // Restore title + fields + tags + is_checked atomically.
                 let fields_json = serde_json::to_string(old_fields)
                     .map_err(KrillnotesError::Json)?;
-                let now = chrono::Utc::now().timestamp();
+                let now = UnixSecs::now();
                 let conn = self.storage.connection_mut();
                 let tx = conn.transaction()?;
                 tx.execute(
@@ -539,7 +539,7 @@ impl Workspace {
                 script_id, name, description,
                 source_code, load_order, enabled, category,
             } => {
-                let now = chrono::Utc::now().timestamp();
+                let now = UnixSecs::now();
                 self.storage.connection().execute(
                     "INSERT OR REPLACE INTO user_scripts
                      (id, name, description, source_code, load_order, enabled,

--- a/krillnotes-core/src/lib.rs
+++ b/krillnotes-core/src/lib.rs
@@ -35,6 +35,7 @@ pub use core::{
     invite::{InviteFile, InviteManager, InviteRecord, InviteResponseFile},
     save_transaction::{SaveResult, SaveTransaction, SoftError},
     storage::Storage,
+    timestamp::UnixSecs,
     undo::{RetractInverse, UndoResult},
     user_script::UserScript,
     peer_registry::PeerInfo,


### PR DESCRIPTION
## Summary

- Adds `UnixSecs(i64)` newtype wrapper that makes the seconds/milliseconds mismatch from #157 a **compile-time error** instead of a runtime bug
- `HlcTimestamp::to_unix_secs()` is the only way to convert HLC milliseconds to seconds for storage
- `Note.created_at/modified_at`, `UserScript.created_at/modified_at`, `AttachmentMeta.created_at` now use `UnixSecs` instead of raw `i64`
- No `From<i64>` impl — forces callers to use `UnixSecs::now()`, `UnixSecs::from_secs()`, or `ts.to_unix_secs()`
- `#[serde(transparent)]` — no frontend/JSON changes needed

**Depends on PR #158** (the runtime fix for the same bug).

Design spec: `docs/superpowers/specs/2026-04-24-unix-secs-newtype-design.md`  
Future work: Approach B (wrap milliseconds side too) documented in [issue #157 comment](https://github.com/2pisoftware/krillnotes/issues/157#issuecomment-4308775671).

## Files changed (17)
| Area | Files | Change |
|------|-------|--------|
| New type | `timestamp.rs` | `UnixSecs` definition + traits |
| HLC | `hlc.rs` | `to_unix_secs()` method |
| Structs | `note.rs`, `user_script.rs`, `attachment.rs` | Field types `i64` → `UnixSecs` |
| Call sites | `notes.rs`, `sync.rs`, `scripts.rs`, `hooks.rs`, `undo.rs`, `attachments.rs`, `export.rs`, `mod.rs` | `chrono::Utc::now().timestamp()` → `UnixSecs::now()` |
| Tests | `tests.rs`, `scripting/tests.rs`, `display_helpers.rs` | Literal `0`/`i64` → `UnixSecs::ZERO`/`UnixSecs::from_secs()` |

## Test plan
- [x] `cargo test -p krillnotes-core` — 608/608 pass
- [x] `cargo check -p krillnotes-desktop` — clean
- [x] No remaining `chrono::Utc::now().timestamp()` in production code (only in `UnixSecs::now()` itself)
- [x] Attempting to assign `ts.wall_ms as i64` to a `UnixSecs` field is now a type error