### PR TITLE
feat: per-operation signature verification and transitive vouching

### DIFF
--- a/krillnotes-core/src/core/export_tests.rs
+++ b/krillnotes-core/src/core/export_tests.rs
@@ -1,4 +1,3 @@
-
 use super::*;
 use crate::core::permission::{AllowAllGate, PermissionGate};
 

--- a/krillnotes-core/src/core/operation_log.rs
+++ b/krillnotes-core/src/core/operation_log.rs
@@ -44,12 +44,19 @@ pub struct OperationSummary {
 /// Records document mutations to the `operations` table and purges stale entries.
 pub struct OperationLog {
     strategy: PurgeStrategy,
+    /// Base64-encoded Ed25519 public key of the local identity.
+    /// Stamped into `verified_by` on every INSERT so self-authored ops
+    /// are immediately marked as verified.
+    identity_pubkey: String,
 }
 
 impl OperationLog {
-    /// Creates a new `OperationLog` with the given purge strategy.
-    pub fn new(strategy: PurgeStrategy) -> Self {
-        Self { strategy }
+    /// Creates a new `OperationLog` with the given purge strategy and identity public key.
+    pub fn new(strategy: PurgeStrategy, identity_pubkey: String) -> Self {
+        Self {
+            strategy,
+            identity_pubkey,
+        }
     }
 
     pub fn purge_strategy(&self) -> &PurgeStrategy {
@@ -67,8 +74,8 @@ impl OperationLog {
         let ts = op.timestamp();
 
         tx.execute(
-            "INSERT INTO operations (operation_id, timestamp_wall_ms, timestamp_counter, timestamp_node_id, device_id, operation_type, operation_data, synced)
-             VALUES (?, ?, ?, ?, ?, ?, ?, 0)",
+            "INSERT INTO operations (operation_id, timestamp_wall_ms, timestamp_counter, timestamp_node_id, device_id, operation_type, operation_data, synced, verified_by)
+             VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?)",
             rusqlite::params![
                 op.operation_id(),
                 ts.wall_ms as i64,
@@ -77,6 +84,7 @@ impl OperationLog {
                 op.device_id(),
                 self.operation_type_name(op),
                 op_json,
+                &self.identity_pubkey,
             ],
         )?;
 
@@ -317,7 +325,7 @@ mod tests {
     fn test_log_and_purge() {
         let temp = NamedTempFile::new().unwrap();
         let mut storage = Storage::create(temp.path(), "").unwrap();
-        let log = OperationLog::new(PurgeStrategy::LocalOnly { keep_last: 5 });
+        let log = OperationLog::new(PurgeStrategy::LocalOnly { keep_last: 5 }, String::new());
 
         let tx = storage.connection_mut().transaction().unwrap();
 
@@ -353,7 +361,7 @@ mod tests {
     fn test_list_operations() {
         let temp = NamedTempFile::new().unwrap();
         let mut storage = Storage::create(temp.path(), "").unwrap();
-        let log = OperationLog::new(PurgeStrategy::LocalOnly { keep_last: 100 });
+        let log = OperationLog::new(PurgeStrategy::LocalOnly { keep_last: 100 }, String::new());
 
         // Insert two operations with different types and timestamps.
         {
@@ -422,7 +430,7 @@ mod tests {
     fn test_purge_all() {
         let temp = NamedTempFile::new().unwrap();
         let mut storage = Storage::create(temp.path(), "").unwrap();
-        let log = OperationLog::new(PurgeStrategy::LocalOnly { keep_last: 100 });
+        let log = OperationLog::new(PurgeStrategy::LocalOnly { keep_last: 100 }, String::new());
 
         {
             let tx = storage.connection_mut().transaction().unwrap();
@@ -450,5 +458,77 @@ mod tests {
 
         let remaining = log.list(storage.connection(), None, None, None).unwrap();
         assert!(remaining.is_empty());
+    }
+
+    #[test]
+    fn test_log_populates_verified_by() {
+        let temp = NamedTempFile::new().unwrap();
+        let mut storage = Storage::create(temp.path(), "").unwrap();
+        let pubkey = "dGVzdC1wdWJrZXktYjY0"; // test pubkey
+        let log = OperationLog::new(
+            PurgeStrategy::LocalOnly { keep_last: 100 },
+            pubkey.to_string(),
+        );
+
+        let tx = storage.connection_mut().transaction().unwrap();
+        let op = Operation::CreateNote {
+            operation_id: "op-verified".to_string(),
+            timestamp: ts(5_000_000),
+            device_id: "dev-1".to_string(),
+            note_id: "note-v".to_string(),
+            parent_id: None,
+            position: 0.0,
+            schema: "TextNote".to_string(),
+            title: "Verified Note".to_string(),
+            fields: BTreeMap::new(),
+            created_by: String::new(),
+            signature: String::new(),
+        };
+        log.log(&tx, &op).unwrap();
+        tx.commit().unwrap();
+
+        let stored: String = storage
+            .connection()
+            .query_row(
+                "SELECT verified_by FROM operations WHERE operation_id = ?",
+                ["op-verified"],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored, pubkey);
+    }
+
+    #[test]
+    fn test_log_verified_by_empty_when_no_identity() {
+        let temp = NamedTempFile::new().unwrap();
+        let mut storage = Storage::create(temp.path(), "").unwrap();
+        let log = OperationLog::new(PurgeStrategy::LocalOnly { keep_last: 100 }, String::new());
+
+        let tx = storage.connection_mut().transaction().unwrap();
+        let op = Operation::CreateNote {
+            operation_id: "op-empty".to_string(),
+            timestamp: ts(6_000_000),
+            device_id: "dev-1".to_string(),
+            note_id: "note-e".to_string(),
+            parent_id: None,
+            position: 0.0,
+            schema: "TextNote".to_string(),
+            title: "Empty Identity Note".to_string(),
+            fields: BTreeMap::new(),
+            created_by: String::new(),
+            signature: String::new(),
+        };
+        log.log(&tx, &op).unwrap();
+        tx.commit().unwrap();
+
+        let stored: String = storage
+            .connection()
+            .query_row(
+                "SELECT verified_by FROM operations WHERE operation_id = ?",
+                ["op-empty"],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored, "");
     }
 }

--- a/krillnotes-core/src/core/operation_log.rs
+++ b/krillnotes-core/src/core/operation_log.rs
@@ -39,6 +39,9 @@ pub struct OperationSummary {
     /// First 8 characters of the base64 public key of the operation author,
     /// or an empty string if the operation has no author (e.g. `RetractOperation`).
     pub author_key: String,
+    /// Base64 public key of the identity that verified (vouched for) this
+    /// operation, or an empty string if not yet verified.
+    pub verified_by: String,
 }
 
 /// Records document mutations to the `operations` table and purges stale entries.
@@ -139,7 +142,7 @@ impl OperationLog {
         until: Option<i64>,
     ) -> Result<Vec<OperationSummary>> {
         let mut sql = String::from(
-            "SELECT operation_id, timestamp_wall_ms, device_id, operation_type, operation_data FROM operations",
+            "SELECT operation_id, timestamp_wall_ms, device_id, operation_type, operation_data, COALESCE(verified_by, '') FROM operations",
         );
         let mut conditions: Vec<String> = Vec::new();
         let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
@@ -175,6 +178,7 @@ impl OperationLog {
         let rows = stmt.query_map(param_refs.as_slice(), |row| {
             let wall_ms_raw: i64 = row.get(1)?;
             let operation_data: String = row.get(4)?;
+            let verified_by: String = row.get(5)?;
             let target_name = Self::extract_target_name(&operation_data);
             let author_key = Self::extract_author_key(&operation_data);
             Ok(OperationSummary {
@@ -184,6 +188,7 @@ impl OperationLog {
                 operation_type: row.get(3)?,
                 target_name,
                 author_key,
+                verified_by,
             })
         })?;
 
@@ -205,12 +210,18 @@ impl OperationLog {
     /// operation is not found, and [`crate::KrillnotesError::Json`] if the
     /// stored data cannot be parsed.
     pub fn get_detail(&self, conn: &Connection, operation_id: &str) -> Result<serde_json::Value> {
-        let raw: String = conn.query_row(
-            "SELECT operation_data FROM operations WHERE operation_id = ?",
+        let (raw, verified_by): (String, String) = conn.query_row(
+            "SELECT operation_data, COALESCE(verified_by, '') FROM operations WHERE operation_id = ?",
             [operation_id],
-            |row| row.get(0),
+            |row| Ok((row.get(0)?, row.get(1)?)),
         )?;
-        let value: serde_json::Value = serde_json::from_str(&raw)?;
+        let mut value: serde_json::Value = serde_json::from_str(&raw)?;
+        if let serde_json::Value::Object(ref mut map) = value {
+            map.insert(
+                "verified_by".to_string(),
+                serde_json::Value::String(verified_by),
+            );
+        }
         Ok(value)
     }
 

--- a/krillnotes-core/src/core/schema.sql
+++ b/krillnotes-core/src/core/schema.sql
@@ -28,7 +28,8 @@ CREATE TABLE IF NOT EXISTS operations (
     operation_type TEXT NOT NULL,
     operation_data TEXT NOT NULL,
     synced INTEGER NOT NULL DEFAULT 0,
-    received_from_peer TEXT
+    received_from_peer TEXT,
+    verified_by TEXT NOT NULL DEFAULT ''
 );
 
 CREATE INDEX IF NOT EXISTS idx_operations_timestamp_wall_ms ON operations(timestamp_wall_ms);

--- a/krillnotes-core/src/core/scripting/tests.rs
+++ b/krillnotes-core/src/core/scripting/tests.rs
@@ -1,4 +1,3 @@
-
 use super::*;
 use crate::core::timestamp::UnixSecs;
 

--- a/krillnotes-core/src/core/storage.rs
+++ b/krillnotes-core/src/core/storage.rs
@@ -467,6 +467,19 @@ impl Storage {
             )?;
         }
 
+        // Migration: add verified_by column to operations table.
+        let verified_by_exists: bool = conn.query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('operations') WHERE name='verified_by'",
+            [],
+            |row| row.get::<_, i64>(0).map(|c| c > 0),
+        )?;
+        if !verified_by_exists {
+            conn.execute(
+                "ALTER TABLE operations ADD COLUMN verified_by TEXT NOT NULL DEFAULT ''",
+                [],
+            )?;
+        }
+
         // Migration: create sync_events table for persistent audit trail.
         conn.execute_batch(
             "CREATE TABLE IF NOT EXISTS sync_events (

--- a/krillnotes-core/src/core/storage_tests.rs
+++ b/krillnotes-core/src/core/storage_tests.rs
@@ -344,6 +344,74 @@ fn test_attachments_table_migration_on_existing_workspace() {
 }
 
 #[test]
+fn test_verified_by_column_exists_on_new_workspace() {
+    let temp = NamedTempFile::new().unwrap();
+    let storage = Storage::create(temp.path(), "").unwrap();
+    let exists: bool = storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('operations') WHERE name='verified_by'",
+            [],
+            |row| row.get::<_, i64>(0).map(|c| c > 0),
+        )
+        .unwrap();
+    assert!(exists, "verified_by column should exist on new workspace");
+}
+
+#[test]
+fn test_verified_by_column_migration_on_existing_workspace() {
+    let temp = NamedTempFile::new().unwrap();
+    // Create a workspace, then verify the migration adds verified_by on open.
+    {
+        let conn = Connection::open(temp.path()).unwrap();
+        conn.execute_batch(include_str!("schema.sql")).unwrap();
+        // Remove the verified_by column by recreating operations without it.
+        conn.execute_batch(
+            "CREATE TABLE operations_tmp (
+                operation_id TEXT NOT NULL PRIMARY KEY,
+                timestamp_wall_ms INTEGER NOT NULL DEFAULT 0,
+                timestamp_counter INTEGER NOT NULL DEFAULT 0,
+                timestamp_node_id INTEGER NOT NULL DEFAULT 0,
+                device_id TEXT NOT NULL,
+                operation_type TEXT NOT NULL,
+                operation_data TEXT NOT NULL,
+                synced INTEGER NOT NULL DEFAULT 0,
+                received_from_peer TEXT
+            );
+            INSERT INTO operations_tmp SELECT operation_id, timestamp_wall_ms,
+                timestamp_counter, timestamp_node_id, device_id, operation_type,
+                operation_data, synced, received_from_peer FROM operations;
+            DROP TABLE operations;
+            ALTER TABLE operations_tmp RENAME TO operations;",
+        )
+        .unwrap();
+        // Confirm verified_by is gone
+        let gone: bool = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('operations') WHERE name='verified_by'",
+                [],
+                |row| row.get::<_, i64>(0).map(|c| c > 0),
+            )
+            .unwrap();
+        assert!(!gone, "verified_by should not exist before migration");
+    }
+    // Open via Storage — migration should add verified_by
+    let storage = Storage::open(temp.path(), "").unwrap();
+    let exists: bool = storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('operations') WHERE name='verified_by'",
+            [],
+            |row| row.get::<_, i64>(0).map(|c| c > 0),
+        )
+        .unwrap();
+    assert!(
+        exists,
+        "verified_by column should exist after migration on open"
+    );
+}
+
+#[test]
 fn test_hlc_index_exists_after_migration() {
     let f = tempfile::NamedTempFile::new().unwrap();
     let s = Storage::create(f.path(), "").unwrap();

--- a/krillnotes-core/src/core/swarm/delta.rs
+++ b/krillnotes-core/src/core/swarm/delta.rs
@@ -24,6 +24,18 @@ use crate::core::swarm::invite::read_zip_file;
 use crate::core::swarm::signature::{sign_manifest, verify_manifest};
 use crate::{KrillnotesError, Result};
 
+/// Wraps an [`Operation`] with optional per-operation verification metadata.
+///
+/// When `verified_by` is `Some`, it contains the base64-encoded public key of
+/// the peer who vouched for this operation (e.g. the workspace owner countersigning
+/// a contributor's op). When `None`, the field is omitted from serialized JSON.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DeltaOperation {
+    pub op: Operation,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verified_by: Option<String>,
+}
+
 pub struct DeltaParams<'a> {
     pub protocol: String,
     pub workspace_id: String,
@@ -32,7 +44,7 @@ pub struct DeltaParams<'a> {
     pub source_display_name: String,
     /// operation_id of the last operation the recipient has seen from us.
     pub since_operation_id: String,
-    pub operations: Vec<Operation>,
+    pub delta_operations: Vec<DeltaOperation>,
     pub sender_key: &'a SigningKey,
     pub recipient_keys: Vec<&'a VerifyingKey>,
     pub recipient_peer_ids: Vec<String>,
@@ -55,7 +67,7 @@ pub struct ParsedDelta {
     pub since_operation_id: String,
     pub sender_public_key: String,
     pub sender_device_id: String,
-    pub operations: Vec<Operation>,
+    pub delta_operations: Vec<DeltaOperation>,
     pub owner_pubkey: Option<String>,
     /// ACK from the sender: the last operation they received FROM us.
     pub ack_operation_id: Option<String>,
@@ -68,7 +80,7 @@ pub fn create_delta_bundle(params: DeltaParams<'_>) -> Result<Vec<u8>> {
     let vk = params.sender_key.verifying_key();
     let pubkey_b64 = BASE64.encode(vk.as_bytes());
 
-    let ops_json = serde_json::to_vec(&params.operations)?;
+    let ops_json = serde_json::to_vec(&params.delta_operations)?;
     let prefixed = super::header::prefix_protocol(&params.protocol, &ops_json);
     let (ciphertext, sym_key, mut entries) =
         encrypt_for_recipients_with_key(&prefixed, &params.recipient_keys)?;
@@ -222,7 +234,7 @@ pub fn parse_delta_bundle(data: &[u8], recipient_key: &SigningKey) -> Result<Par
     // Strip the protocol tag embedded before encryption.
     let (protocol, ops_json) = super::header::strip_protocol(&decrypted)?;
 
-    let operations: Vec<Operation> = serde_json::from_slice(&ops_json)?;
+    let delta_operations: Vec<DeltaOperation> = serde_json::from_slice(&ops_json)?;
 
     // Decrypt sidecar blobs from the already-read ciphertext.
     let mut attachment_blobs = Vec::new();
@@ -237,7 +249,7 @@ pub fn parse_delta_bundle(data: &[u8], recipient_key: &SigningKey) -> Result<Par
         since_operation_id: header.since_operation_id.unwrap_or_default(),
         sender_public_key: header.source_identity,
         sender_device_id: header.source_device_id,
-        operations,
+        delta_operations,
         owner_pubkey: header.owner_pubkey,
         ack_operation_id: header.ack_operation_id,
         attachment_blobs,
@@ -275,7 +287,6 @@ mod tests {
     fn test_delta_roundtrip() {
         let sender_key = make_key();
         let recipient_key = make_key();
-        let ops = vec![dummy_op("op-1"), dummy_op("op-2")];
 
         let bundle = create_delta_bundle(DeltaParams {
             protocol: "test".to_string(),
@@ -284,7 +295,10 @@ mod tests {
             source_device_id: "dev-1".to_string(),
             source_display_name: "Alice".to_string(),
             since_operation_id: "op-0".to_string(),
-            operations: ops.clone(),
+            delta_operations: vec![
+                DeltaOperation { op: dummy_op("op-1"), verified_by: None },
+                DeltaOperation { op: dummy_op("op-2"), verified_by: Some("voucher-pk".to_string()) },
+            ],
             sender_key: &sender_key,
             recipient_keys: vec![&recipient_key.verifying_key()],
             recipient_peer_ids: vec!["dev-2".to_string()],
@@ -297,8 +311,11 @@ mod tests {
 
         let parsed = parse_delta_bundle(&bundle, &recipient_key).unwrap();
         assert_eq!(parsed.sender_device_id, "dev-1");
-        assert_eq!(parsed.operations.len(), 2);
-        assert_eq!(parsed.operations[0].operation_id(), "op-1");
+        assert_eq!(parsed.delta_operations.len(), 2);
+        assert_eq!(parsed.delta_operations[0].op.operation_id(), "op-1");
+        assert_eq!(parsed.delta_operations[0].verified_by, None);
+        assert_eq!(parsed.delta_operations[1].op.operation_id(), "op-2");
+        assert_eq!(parsed.delta_operations[1].verified_by, Some("voucher-pk".to_string()));
         assert_eq!(parsed.since_operation_id, "op-0");
     }
 
@@ -314,7 +331,7 @@ mod tests {
             source_device_id: "dev-1".to_string(),
             source_display_name: "Alice".to_string(),
             since_operation_id: "op-0".to_string(),
-            operations: vec![],
+            delta_operations: vec![],
             sender_key: &sender_key,
             recipient_keys: vec![&recipient_key.verifying_key()],
             recipient_peer_ids: vec!["dev-2".to_string()],
@@ -326,7 +343,7 @@ mod tests {
         .unwrap();
 
         let parsed = parse_delta_bundle(&bundle, &recipient_key).unwrap();
-        assert_eq!(parsed.operations.len(), 0);
+        assert_eq!(parsed.delta_operations.len(), 0);
     }
 
     #[test]
@@ -364,7 +381,7 @@ mod tests {
             source_device_id: "dev-1".to_string(),
             source_display_name: "Alice".to_string(),
             since_operation_id: String::new(),
-            operations: vec![op],
+            delta_operations: vec![DeltaOperation { op, verified_by: None }],
             sender_key: &sender_key,
             recipient_keys: vec![&recipient_vk],
             recipient_peer_ids: vec!["peer-1".to_string()],
@@ -377,7 +394,7 @@ mod tests {
         let bundle = create_delta_bundle(params).unwrap();
         let parsed = parse_delta_bundle(&bundle, &recipient_key).unwrap();
 
-        assert_eq!(parsed.operations.len(), 1);
+        assert_eq!(parsed.delta_operations.len(), 1);
         assert_eq!(parsed.attachment_blobs.len(), 1);
         assert_eq!(parsed.attachment_blobs[0].0, "att-uuid-1");
         assert_eq!(parsed.attachment_blobs[0].1, blob_data);
@@ -441,7 +458,7 @@ mod tests {
             source_device_id: "dev-1".to_string(),
             source_display_name: "Alice".to_string(),
             since_operation_id: String::new(),
-            operations: vec![op],
+            delta_operations: vec![DeltaOperation { op, verified_by: None }],
             sender_key: &sender_key,
             recipient_keys: vec![&recipient_vk],
             recipient_peer_ids: vec!["peer-1".to_string()],
@@ -499,7 +516,7 @@ mod tests {
             source_device_id: "dev-1".to_string(),
             source_display_name: "Alice".to_string(),
             since_operation_id: String::new(),
-            operations: vec![op],
+            delta_operations: vec![DeltaOperation { op, verified_by: None }],
             sender_key: &sender_key,
             recipient_keys: vec![&recipient_vk],
             recipient_peer_ids: vec!["peer-1".to_string()],
@@ -512,7 +529,49 @@ mod tests {
         let bundle = create_delta_bundle(params).unwrap();
         let parsed = parse_delta_bundle(&bundle, &recipient_key).unwrap();
 
-        assert_eq!(parsed.operations.len(), 1);
+        assert_eq!(parsed.delta_operations.len(), 1);
         assert!(parsed.attachment_blobs.is_empty());
+    }
+
+    #[test]
+    fn test_delta_operation_serde_roundtrip() {
+        // With verified_by = Some → field present in JSON
+        let with_voucher = DeltaOperation {
+            op: dummy_op("op-v1"),
+            verified_by: Some("voucher-pk-base64".to_string()),
+        };
+        let json_with = serde_json::to_string(&with_voucher).unwrap();
+        assert!(
+            json_with.contains("\"verified_by\""),
+            "verified_by should be present when Some: {json_with}"
+        );
+        let deser_with: DeltaOperation = serde_json::from_str(&json_with).unwrap();
+        assert_eq!(deser_with.op.operation_id(), "op-v1");
+        assert_eq!(
+            deser_with.verified_by,
+            Some("voucher-pk-base64".to_string())
+        );
+
+        // With verified_by = None → field omitted from JSON
+        let without_voucher = DeltaOperation {
+            op: dummy_op("op-v2"),
+            verified_by: None,
+        };
+        let json_without = serde_json::to_string(&without_voucher).unwrap();
+        assert!(
+            !json_without.contains("verified_by"),
+            "verified_by should be omitted when None: {json_without}"
+        );
+        let deser_without: DeltaOperation = serde_json::from_str(&json_without).unwrap();
+        assert_eq!(deser_without.op.operation_id(), "op-v2");
+        assert_eq!(deser_without.verified_by, None);
+
+        // Deserialization from JSON without verified_by field → defaults to None.
+        // Build the JSON dynamically from a real Operation to match the actual serde shape.
+        let op_json = serde_json::to_string(&dummy_op("op-v3")).unwrap();
+        let bare_json = format!(r#"{{"op":{op_json}}}"#);
+        let deser_bare: DeltaOperation = serde_json::from_str(&bare_json).unwrap();
+        assert_eq!(deser_bare.op.operation_id(), "op-v3");
+        assert_eq!(deser_bare.verified_by, None);
     }
 }

--- a/krillnotes-core/src/core/swarm/delta.rs
+++ b/krillnotes-core/src/core/swarm/delta.rs
@@ -296,8 +296,14 @@ mod tests {
             source_display_name: "Alice".to_string(),
             since_operation_id: "op-0".to_string(),
             delta_operations: vec![
-                DeltaOperation { op: dummy_op("op-1"), verified_by: None },
-                DeltaOperation { op: dummy_op("op-2"), verified_by: Some("voucher-pk".to_string()) },
+                DeltaOperation {
+                    op: dummy_op("op-1"),
+                    verified_by: None,
+                },
+                DeltaOperation {
+                    op: dummy_op("op-2"),
+                    verified_by: Some("voucher-pk".to_string()),
+                },
             ],
             sender_key: &sender_key,
             recipient_keys: vec![&recipient_key.verifying_key()],
@@ -315,7 +321,10 @@ mod tests {
         assert_eq!(parsed.delta_operations[0].op.operation_id(), "op-1");
         assert_eq!(parsed.delta_operations[0].verified_by, None);
         assert_eq!(parsed.delta_operations[1].op.operation_id(), "op-2");
-        assert_eq!(parsed.delta_operations[1].verified_by, Some("voucher-pk".to_string()));
+        assert_eq!(
+            parsed.delta_operations[1].verified_by,
+            Some("voucher-pk".to_string())
+        );
         assert_eq!(parsed.since_operation_id, "op-0");
     }
 
@@ -381,7 +390,10 @@ mod tests {
             source_device_id: "dev-1".to_string(),
             source_display_name: "Alice".to_string(),
             since_operation_id: String::new(),
-            delta_operations: vec![DeltaOperation { op, verified_by: None }],
+            delta_operations: vec![DeltaOperation {
+                op,
+                verified_by: None,
+            }],
             sender_key: &sender_key,
             recipient_keys: vec![&recipient_vk],
             recipient_peer_ids: vec!["peer-1".to_string()],
@@ -458,7 +470,10 @@ mod tests {
             source_device_id: "dev-1".to_string(),
             source_display_name: "Alice".to_string(),
             since_operation_id: String::new(),
-            delta_operations: vec![DeltaOperation { op, verified_by: None }],
+            delta_operations: vec![DeltaOperation {
+                op,
+                verified_by: None,
+            }],
             sender_key: &sender_key,
             recipient_keys: vec![&recipient_vk],
             recipient_peer_ids: vec!["peer-1".to_string()],
@@ -516,7 +531,10 @@ mod tests {
             source_device_id: "dev-1".to_string(),
             source_display_name: "Alice".to_string(),
             since_operation_id: String::new(),
-            delta_operations: vec![DeltaOperation { op, verified_by: None }],
+            delta_operations: vec![DeltaOperation {
+                op,
+                verified_by: None,
+            }],
             sender_key: &sender_key,
             recipient_keys: vec![&recipient_vk],
             recipient_peer_ids: vec!["peer-1".to_string()],

--- a/krillnotes-core/src/core/swarm/delta.rs
+++ b/krillnotes-core/src/core/swarm/delta.rs
@@ -592,4 +592,91 @@ mod tests {
         assert_eq!(deser_bare.op.operation_id(), "op-v3");
         assert_eq!(deser_bare.verified_by, None);
     }
+
+    #[test]
+    fn test_full_chain_a_to_b_to_c() {
+        // Three identities
+        let key_a = make_key();
+        let key_b = make_key();
+        let key_c = make_key();
+        let pubkey_a = BASE64.encode(key_a.verifying_key().as_bytes());
+        let pubkey_b = BASE64.encode(key_b.verifying_key().as_bytes());
+        let pubkey_c = BASE64.encode(key_c.verifying_key().as_bytes());
+
+        // A creates and signs an operation
+        let mut op = dummy_op("chain-1");
+        op.sign(&key_a);
+
+        // === A sends delta to B (self-authored, no verified_by) ===
+        let bundle_a_to_b = create_delta_bundle(DeltaParams {
+            protocol: "krillnotes/1".into(),
+            workspace_id: "ws-chain".into(),
+            workspace_name: "Chain WS".into(),
+            source_device_id: "dev-a".into(),
+            source_display_name: "Alice".into(),
+            since_operation_id: String::new(),
+            delta_operations: vec![DeltaOperation {
+                op: op.clone(),
+                verified_by: None,
+            }],
+            sender_key: &key_a,
+            recipient_keys: vec![&key_b.verifying_key()],
+            recipient_peer_ids: vec!["dev-b".to_string()],
+            recipient_identity_id: pubkey_b.clone(),
+            owner_pubkey: pubkey_a.clone(),
+            ack_operation_id: None,
+            attachment_blobs: vec![],
+        })
+        .unwrap();
+
+        // B parses — verified_by should be None (A authored it)
+        let parsed_at_b = parse_delta_bundle(&bundle_a_to_b, &key_b).unwrap();
+        assert_eq!(parsed_at_b.delta_operations.len(), 1);
+        assert_eq!(parsed_at_b.delta_operations[0].verified_by, None);
+
+        // B verifies A's signature (A is B's direct peer)
+        assert!(parsed_at_b.delta_operations[0]
+            .op
+            .verify(&key_a.verifying_key()));
+
+        // === B sends to C, vouching for A's op ===
+        let bundle_b_to_c = create_delta_bundle(DeltaParams {
+            protocol: "krillnotes/1".into(),
+            workspace_id: "ws-chain".into(),
+            workspace_name: "Chain WS".into(),
+            source_device_id: "dev-b".into(),
+            source_display_name: "Bob".into(),
+            since_operation_id: String::new(),
+            delta_operations: vec![DeltaOperation {
+                op: op.clone(),
+                verified_by: Some(pubkey_b.clone()), // B vouches
+            }],
+            sender_key: &key_b,
+            recipient_keys: vec![&key_c.verifying_key()],
+            recipient_peer_ids: vec!["dev-c".to_string()],
+            recipient_identity_id: pubkey_c.clone(),
+            owner_pubkey: pubkey_a.clone(),
+            ack_operation_id: None,
+            attachment_blobs: vec![],
+        })
+        .unwrap();
+
+        // C parses — sees B's vouch
+        let parsed_at_c = parse_delta_bundle(&bundle_b_to_c, &key_c).unwrap();
+        assert_eq!(parsed_at_c.delta_operations.len(), 1);
+        assert_eq!(
+            parsed_at_c.delta_operations[0].verified_by,
+            Some(pubkey_b.clone())
+        );
+        assert_eq!(parsed_at_c.sender_public_key, pubkey_b);
+
+        // C can accept: verified_by matches sender_public_key
+        assert_eq!(
+            parsed_at_c.delta_operations[0]
+                .verified_by
+                .as_ref()
+                .unwrap(),
+            &parsed_at_c.sender_public_key,
+        );
+    }
 }

--- a/krillnotes-core/src/core/swarm/mod.rs
+++ b/krillnotes-core/src/core/swarm/mod.rs
@@ -20,7 +20,9 @@ mod integration_tests {
 
     use crate::core::hlc::HlcTimestamp;
     use crate::core::operation::Operation;
-    use crate::core::swarm::delta::{create_delta_bundle, parse_delta_bundle, DeltaParams};
+    use crate::core::swarm::delta::{
+        create_delta_bundle, parse_delta_bundle, DeltaOperation, DeltaParams,
+    };
     use crate::core::swarm::invite::*;
     use crate::core::swarm::snapshot::{
         create_snapshot_bundle, parse_snapshot_bundle, SnapshotParams,
@@ -124,6 +126,13 @@ mod integration_tests {
 
         // === Step 7: Alice sends delta to Bob ===
         let alice_ops = vec![dummy_op("op-1", "note-abc"), dummy_op("op-2", "note-abc")];
+        let alice_delta_ops: Vec<DeltaOperation> = alice_ops
+            .iter()
+            .map(|op| DeltaOperation {
+                op: op.clone(),
+                verified_by: None,
+            })
+            .collect();
         let delta_bundle = create_delta_bundle(DeltaParams {
             protocol: "test".to_string(),
             workspace_id: "ws-alpha".to_string(),
@@ -131,7 +140,7 @@ mod integration_tests {
             source_device_id: "dev-alice".to_string(),
             source_display_name: "Alice".to_string(),
             since_operation_id: "op-baseline".to_string(),
-            operations: alice_ops.clone(),
+            delta_operations: alice_delta_ops,
             sender_key: &alice_key,
             recipient_keys: vec![&bob_key.verifying_key()],
             recipient_peer_ids: vec!["dev-bob".to_string()],
@@ -144,8 +153,8 @@ mod integration_tests {
 
         // === Step 8: Bob applies delta ===
         let parsed_delta = parse_delta_bundle(&delta_bundle, &bob_key).unwrap();
-        assert_eq!(parsed_delta.operations.len(), 2);
-        assert_eq!(parsed_delta.operations[0].operation_id(), "op-1");
+        assert_eq!(parsed_delta.delta_operations.len(), 2);
+        assert_eq!(parsed_delta.delta_operations[0].op.operation_id(), "op-1");
         assert_eq!(parsed_delta.since_operation_id, "op-baseline");
     }
 }

--- a/krillnotes-core/src/core/swarm/sync.rs
+++ b/krillnotes-core/src/core/swarm/sync.rs
@@ -76,10 +76,8 @@ pub fn generate_delta(
 
     // 2. Collect operations since watermark with verified_by metadata,
     //    excluding this peer's own ops.
-    let ops_with_vb = workspace.operations_since_with_verified_by(
-        peer.last_sent_op.as_deref(),
-        &peer.peer_device_id,
-    )?;
+    let ops_with_vb = workspace
+        .operations_since_with_verified_by(peer.last_sent_op.as_deref(), &peer.peer_device_id)?;
 
     // 2b. Wrap each operation in a DeltaOperation with appropriate vouching.
     let my_pubkey = workspace.identity_pubkey().to_string();
@@ -1224,7 +1222,8 @@ mod tests {
         for (op, verified_by) in &results {
             // Self-authored ops should have verified_by = the workspace identity pubkey.
             assert_eq!(
-                verified_by, &alice_pubkey,
+                verified_by,
+                &alice_pubkey,
                 "verified_by should match workspace identity pubkey for op {}",
                 op.operation_id()
             );
@@ -1301,7 +1300,8 @@ mod tests {
             crate::core::swarm::delta::parse_delta_bundle(&bundle1.bundle_bytes, &bob_key).unwrap();
         for d_op in &parsed1.delta_operations {
             assert_eq!(
-                d_op.verified_by, None,
+                d_op.verified_by,
+                None,
                 "self-authored ops should have verified_by = None, op={}",
                 d_op.op.operation_id()
             );

--- a/krillnotes-core/src/core/swarm/sync.rs
+++ b/krillnotes-core/src/core/swarm/sync.rs
@@ -74,16 +74,37 @@ pub fn generate_delta(
         KrillnotesError::Swarm(format!("peer {peer_device_id} not found in registry"))
     })?;
 
-    // 2. Collect operations since watermark, excluding this peer's own ops.
-    //    When last_sent_op is None (force-resync), operations_since(None) returns all ops.
-    let ops = workspace.operations_since(peer.last_sent_op.as_deref(), &peer.peer_device_id)?;
+    // 2. Collect operations since watermark with verified_by metadata,
+    //    excluding this peer's own ops.
+    let ops_with_vb = workspace.operations_since_with_verified_by(
+        peer.last_sent_op.as_deref(),
+        &peer.peer_device_id,
+    )?;
 
-    // 2b. Wrap each operation in a DeltaOperation (verified_by populated by Task 6).
-    let delta_operations: Vec<DeltaOperation> = ops
+    // 2b. Wrap each operation in a DeltaOperation with appropriate vouching.
+    let my_pubkey = workspace.identity_pubkey().to_string();
+
+    let delta_operations: Vec<DeltaOperation> = ops_with_vb
         .into_iter()
-        .map(|op| DeltaOperation {
-            op,
-            verified_by: None,
+        .filter_map(|(op, verified_by)| {
+            if op.author_key() == my_pubkey {
+                // Self-authored: receiver verifies my sig directly
+                Some(DeltaOperation {
+                    op,
+                    verified_by: None,
+                })
+            } else if !verified_by.is_empty() {
+                // Previously verified/vouched: I re-vouch
+                Some(DeltaOperation {
+                    op,
+                    verified_by: Some(my_pubkey.clone()),
+                })
+            } else {
+                // Unverified op — do not include in delta
+                log::warn!(target: "krillnotes::sync",
+                    "skipping unverified op {} in delta", op.operation_id());
+                None
+            }
         })
         .collect();
 
@@ -1171,6 +1192,188 @@ mod tests {
         assert!(
             !bob_enc_path.exists(),
             "Bob's .enc file must be deleted after remove sync"
+        );
+    }
+
+    /// operations_since_with_verified_by returns (op, verified_by) tuples
+    /// where verified_by matches the workspace's identity pubkey for self-authored ops.
+    #[test]
+    fn test_operations_since_with_verified_by_returns_column() {
+        let alice_key = make_key();
+        let alice_pubkey = b64(&alice_key);
+
+        let temp = tempfile::NamedTempFile::new().unwrap();
+        let mut ws = crate::core::workspace::Workspace::create(
+            temp.path(),
+            "",
+            "alice-dev",
+            SigningKey::from_bytes(&alice_key.to_bytes()),
+            test_gate(),
+            None,
+        )
+        .unwrap();
+
+        // Create a note — this generates self-authored operations.
+        ws.create_note_root("TextNote").unwrap();
+
+        let results = ws
+            .operations_since_with_verified_by(None, "other-dev")
+            .unwrap();
+
+        assert!(!results.is_empty(), "should have at least one op");
+        for (op, verified_by) in &results {
+            // Self-authored ops should have verified_by = the workspace identity pubkey.
+            assert_eq!(
+                verified_by, &alice_pubkey,
+                "verified_by should match workspace identity pubkey for op {}",
+                op.operation_id()
+            );
+        }
+    }
+
+    /// generate_delta sets verified_by = None for self-authored ops and
+    /// verified_by = Some(sender_pubkey) for re-vouched ops from other authors.
+    #[test]
+    fn test_generate_delta_vouching_logic() {
+        let alice_key = make_key();
+        let bob_key = make_key();
+        let carol_key = make_key();
+        let alice_pubkey = b64(&alice_key);
+        let bob_pubkey = b64(&bob_key);
+        let carol_pubkey = b64(&carol_key);
+
+        // ── Alice workspace ──
+        let alice_dir = tempfile::tempdir().unwrap();
+        let alice_db = alice_dir.path().join("alice.db");
+        let mut alice_ws = crate::core::workspace::Workspace::create(
+            &alice_db,
+            "",
+            "alice-dev",
+            SigningKey::from_bytes(&alice_key.to_bytes()),
+            test_gate(),
+            None,
+        )
+        .unwrap();
+
+        // Alice creates a note (self-authored).
+        alice_ws.create_note_root("TextNote").unwrap();
+
+        // Record watermark, then register Bob as peer.
+        let snap_op = alice_ws
+            .get_latest_operation_id()
+            .unwrap()
+            .unwrap_or_default();
+        alice_ws
+            .upsert_sync_peer("dev-bob", &bob_pubkey, Some(&snap_op), None)
+            .unwrap();
+
+        // Alice creates another note after the watermark — this will be in the delta.
+        alice_ws.create_note_root("TextNote").unwrap();
+
+        // Set up contact manager with Bob.
+        let cm_dir = tempfile::tempdir().unwrap();
+        let alice_cm = crate::core::contact::ContactManager::for_identity(
+            cm_dir.path().to_path_buf(),
+            [50u8; 32],
+        )
+        .unwrap();
+        alice_cm
+            .find_or_create_by_public_key(
+                "Bob",
+                &bob_pubkey,
+                crate::core::contact::TrustLevel::Tofu,
+            )
+            .unwrap();
+
+        // Generate delta #1: should contain only self-authored ops with verified_by = None.
+        let bundle1 = super::generate_delta(
+            &mut alice_ws,
+            "dev-bob",
+            "TestWorkspace",
+            &alice_key,
+            "Alice",
+            &alice_cm,
+        )
+        .unwrap();
+        assert!(bundle1.op_count > 0, "delta should have ops");
+
+        let parsed1 =
+            crate::core::swarm::delta::parse_delta_bundle(&bundle1.bundle_bytes, &bob_key).unwrap();
+        for d_op in &parsed1.delta_operations {
+            assert_eq!(
+                d_op.verified_by, None,
+                "self-authored ops should have verified_by = None, op={}",
+                d_op.op.operation_id()
+            );
+        }
+
+        // ── Now simulate receiving a Carol op via apply_incoming_operation ──
+        // Build a signed op from Carol.
+        let carol_op = {
+            let mut op = crate::core::operation::Operation::UpdateNote {
+                operation_id: uuid::Uuid::new_v4().to_string(),
+                timestamp: crate::core::hlc::HlcTimestamp {
+                    wall_ms: chrono::Utc::now().timestamp_millis() as u64 + 10000,
+                    counter: 0,
+                    node_id: 999,
+                },
+                device_id: "carol-dev".to_string(),
+                note_id: alice_ws.list_all_notes().unwrap()[0].id.clone(),
+                title: "Carol's update".to_string(),
+                modified_by: carol_pubkey.clone(),
+                signature: String::new(),
+            };
+            op.sign(&carol_key);
+            op
+        };
+
+        // Apply Carol's op as incoming — Alice verifies sig and stores with verified_by.
+        let applied = alice_ws
+            .apply_incoming_operation(
+                carol_op.clone(),
+                "carol-dev",
+                &[],
+                None, // sender-authored path: no explicit vouch needed
+                &carol_pubkey,
+            )
+            .unwrap();
+        assert!(applied, "Carol's op should be applied");
+
+        // Advance watermark to include Alice's ops from delta #1.
+        alice_ws
+            .upsert_sync_peer(
+                "dev-bob",
+                &bob_pubkey,
+                bundle1.last_included_op.as_deref(),
+                None,
+            )
+            .unwrap();
+
+        // Generate delta #2: should contain Carol's op re-vouched by Alice.
+        let bundle2 = super::generate_delta(
+            &mut alice_ws,
+            "dev-bob",
+            "TestWorkspace",
+            &alice_key,
+            "Alice",
+            &alice_cm,
+        )
+        .unwrap();
+        assert!(bundle2.op_count > 0, "delta #2 should have Carol's op");
+
+        let parsed2 =
+            crate::core::swarm::delta::parse_delta_bundle(&bundle2.bundle_bytes, &bob_key).unwrap();
+
+        // Find Carol's op in the delta and verify Alice re-vouched it.
+        let carol_delta = parsed2
+            .delta_operations
+            .iter()
+            .find(|d| d.op.operation_id() == carol_op.operation_id())
+            .expect("Carol's op should be in the delta");
+        assert_eq!(
+            carol_delta.verified_by,
+            Some(alice_pubkey.clone()),
+            "Carol's op should be re-vouched by Alice"
         );
     }
 }

--- a/krillnotes-core/src/core/swarm/sync.rs
+++ b/krillnotes-core/src/core/swarm/sync.rs
@@ -21,7 +21,9 @@ use serde::Serialize;
 
 use crate::core::contact::{ContactManager, TrustLevel};
 use crate::core::operation::Operation;
-use crate::core::swarm::delta::{create_delta_bundle, parse_delta_bundle, DeltaParams};
+use crate::core::swarm::delta::{
+    create_delta_bundle, parse_delta_bundle, DeltaOperation, DeltaParams,
+};
 use crate::core::workspace::Workspace;
 use crate::{KrillnotesError, Result};
 
@@ -76,10 +78,19 @@ pub fn generate_delta(
     //    When last_sent_op is None (force-resync), operations_since(None) returns all ops.
     let ops = workspace.operations_since(peer.last_sent_op.as_deref(), &peer.peer_device_id)?;
 
+    // 2b. Wrap each operation in a DeltaOperation (verified_by populated by Task 6).
+    let delta_operations: Vec<DeltaOperation> = ops
+        .into_iter()
+        .map(|op| DeltaOperation {
+            op,
+            verified_by: None,
+        })
+        .collect();
+
     // 3. Collect plaintext attachment blobs for any AddAttachment ops in the batch.
     let mut attachment_blobs: Vec<(String, Vec<u8>)> = Vec::new();
-    for op in &ops {
-        if let Operation::AddAttachment { attachment_id, .. } = op {
+    for delta_op in &delta_operations {
+        if let Operation::AddAttachment { attachment_id, .. } = &delta_op.op {
             match workspace.get_attachment_bytes(attachment_id) {
                 Ok(bytes) => attachment_blobs.push((attachment_id.clone(), bytes)),
                 Err(e) => {
@@ -123,8 +134,10 @@ pub fn generate_delta(
     // so that multiple identities on the same machine have distinct source IDs.
     let source_device_id = workspace.device_id().to_string();
 
-    let op_count = ops.len();
-    let last_included_op = ops.last().map(|op| op.operation_id().to_string());
+    let op_count = delta_operations.len();
+    let last_included_op = delta_operations
+        .last()
+        .map(|d| d.op.operation_id().to_string());
 
     let bundle_bytes = create_delta_bundle(DeltaParams {
         protocol: workspace.protocol_id().to_string(),
@@ -133,7 +146,7 @@ pub fn generate_delta(
         source_device_id,
         source_display_name: sender_display_name.to_string(),
         since_operation_id: peer.last_sent_op.clone().unwrap_or_default(),
-        operations: ops,
+        delta_operations,
         sender_key: signing_key,
         recipient_keys: vec![&recipient_vk],
         recipient_peer_ids: vec![peer_device_id.to_string()],
@@ -227,7 +240,8 @@ pub fn apply_delta(
     let mut new_tofu_contacts: Vec<String> = Vec::new();
 
     // 3. Apply each operation in chronological order.
-    for op in &parsed.operations {
+    for delta_op in &parsed.delta_operations {
+        let op = &delta_op.op;
         // TOFU: auto-register unknown authors.
         let author_key = op.author_key();
         if !author_key.is_empty() && contact_manager.find_by_public_key(author_key)?.is_none() {
@@ -258,9 +272,9 @@ pub fn apply_delta(
     //    bundle are duplicates, tracking only applied ops makes the ACK lag behind
     //    the sender's watermark, triggering an infinite full-resend loop.
     let last_bundle_op_id = parsed
-        .operations
+        .delta_operations
         .last()
-        .map(|op| op.operation_id().to_string());
+        .map(|d| d.op.operation_id().to_string());
     let last_received = last_bundle_op_id.as_deref();
     workspace.upsert_peer_from_delta(
         &parsed.sender_device_id,

--- a/krillnotes-core/src/core/swarm/sync.rs
+++ b/krillnotes-core/src/core/swarm/sync.rs
@@ -259,6 +259,8 @@ pub fn apply_delta(
             op.clone(),
             &parsed.sender_device_id,
             &parsed.attachment_blobs,
+            delta_op.verified_by.as_deref(),
+            &parsed.sender_public_key,
         )? {
             applied += 1;
         } else {

--- a/krillnotes-core/src/core/sync/mod.rs
+++ b/krillnotes-core/src/core/sync/mod.rs
@@ -336,6 +336,8 @@ impl SyncEngine {
         struct OpEntry {
             op: Operation,
             sender_device_id: String,
+            sender_public_key: String,
+            verified_by: Option<String>,
             bundle_ack: Option<String>,
             attachment_blobs: Arc<Vec<(String, Vec<u8>)>>, // shared ref to parent delta's blobs
         }
@@ -344,14 +346,20 @@ impl SyncEngine {
             .iter()
             .flat_map(|pd| {
                 let sender = pd.parsed.sender_device_id.clone();
+                let sender_pk = pd.parsed.sender_public_key.clone();
                 let ack = pd.parsed.ack_operation_id.clone();
                 let blobs = Arc::new(pd.parsed.attachment_blobs.clone());
-                pd.parsed.delta_operations.iter().map(move |delta_op| OpEntry {
-                    op: delta_op.op.clone(),
-                    sender_device_id: sender.clone(),
-                    bundle_ack: ack.clone(),
-                    attachment_blobs: Arc::clone(&blobs),
-                })
+                pd.parsed
+                    .delta_operations
+                    .iter()
+                    .map(move |delta_op| OpEntry {
+                        op: delta_op.op.clone(),
+                        sender_device_id: sender.clone(),
+                        sender_public_key: sender_pk.clone(),
+                        verified_by: delta_op.verified_by.clone(),
+                        bundle_ack: ack.clone(),
+                        attachment_blobs: Arc::clone(&blobs),
+                    })
             })
             .collect();
 
@@ -388,6 +396,8 @@ impl SyncEngine {
                 entry.op.clone(),
                 &entry.sender_device_id,
                 &entry.attachment_blobs,
+                entry.verified_by.as_deref(),
+                &entry.sender_public_key,
             ) {
                 Ok(true) => {
                     log::debug!(target: "krillnotes::sync",

--- a/krillnotes-core/src/core/sync/mod.rs
+++ b/krillnotes-core/src/core/sync/mod.rs
@@ -346,8 +346,8 @@ impl SyncEngine {
                 let sender = pd.parsed.sender_device_id.clone();
                 let ack = pd.parsed.ack_operation_id.clone();
                 let blobs = Arc::new(pd.parsed.attachment_blobs.clone());
-                pd.parsed.operations.iter().map(move |op| OpEntry {
-                    op: op.clone(),
+                pd.parsed.delta_operations.iter().map(move |delta_op| OpEntry {
+                    op: delta_op.op.clone(),
                     sender_device_id: sender.clone(),
                     bundle_ack: ack.clone(),
                     attachment_blobs: Arc::clone(&blobs),
@@ -512,7 +512,7 @@ impl SyncEngine {
         // Also check senders who only sent 0-op ack bundles (not in sender_last_op).
         for pd in &pending_deltas {
             let sender = &pd.parsed.sender_device_id;
-            if pd.parsed.operations.is_empty() && ack_checked.insert(sender.clone()) {
+            if pd.parsed.delta_operations.is_empty() && ack_checked.insert(sender.clone()) {
                 run_ack_check(
                     sender,
                     &pd.parsed.ack_operation_id,

--- a/krillnotes-core/src/core/workspace/mod.rs
+++ b/krillnotes-core/src/core/workspace/mod.rs
@@ -148,9 +148,19 @@ impl Workspace {
         let mut storage = Storage::create(&path, password)?;
         let mut script_registry = ScriptRegistry::new()?;
         let purge_limit = Self::read_purge_limit_from_meta(storage.connection());
-        let operation_log = OperationLog::new(PurgeStrategy::LocalOnly {
-            keep_last: purge_limit,
-        });
+
+        let identity_pubkey_b64 = {
+            use base64::Engine as _;
+            let pubkey = ed25519_dalek::VerifyingKey::from(&signing_key);
+            base64::engine::general_purpose::STANDARD.encode(pubkey.as_bytes())
+        };
+
+        let operation_log = OperationLog::new(
+            PurgeStrategy::LocalOnly {
+                keep_last: purge_limit,
+            },
+            identity_pubkey_b64.clone(),
+        );
 
         let device_id = if let Some(dir) = identity_dir {
             let device_uuid = crate::core::identity::ensure_device_uuid(dir)?;
@@ -258,12 +268,6 @@ impl Workspace {
             }
             script_registry.resolve_bindings();
         }
-
-        let identity_pubkey_b64 = {
-            use base64::Engine as _;
-            let pubkey = ed25519_dalek::VerifyingKey::from(&signing_key);
-            base64::engine::general_purpose::STANDARD.encode(pubkey.as_bytes())
-        };
 
         storage.connection().execute(
             "INSERT INTO workspace_meta (key, value) VALUES (?, ?)",
@@ -491,9 +495,20 @@ impl Workspace {
         let storage = Storage::open(&path, password)?;
         let script_registry = ScriptRegistry::new()?;
         let purge_limit = Self::read_purge_limit_from_meta(storage.connection());
-        let operation_log = OperationLog::new(PurgeStrategy::LocalOnly {
-            keep_last: purge_limit,
-        });
+
+        // Derive the base64-encoded public key from the signing key.
+        let identity_pubkey_b64 = {
+            use base64::Engine as _;
+            let pubkey = ed25519_dalek::VerifyingKey::from(&signing_key);
+            base64::engine::general_purpose::STANDARD.encode(pubkey.as_bytes())
+        };
+
+        let operation_log = OperationLog::new(
+            PurgeStrategy::LocalOnly {
+                keep_last: purge_limit,
+            },
+            identity_pubkey_b64.clone(),
+        );
 
         // Read metadata from database
         let mut device_id: String = storage.connection().query_row(
@@ -517,13 +532,6 @@ impl Workspace {
                 device_id = composite;
             }
         }
-
-        // Derive the base64-encoded public key from the signing key.
-        let identity_pubkey_b64 = {
-            use base64::Engine as _;
-            let pubkey = ed25519_dalek::VerifyingKey::from(&signing_key);
-            base64::engine::general_purpose::STANDARD.encode(pubkey.as_bytes())
-        };
 
         let workspace_root = path
             .as_ref()

--- a/krillnotes-core/src/core/workspace/scripts.rs
+++ b/krillnotes-core/src/core/workspace/scripts.rs
@@ -567,6 +567,25 @@ impl Workspace {
         self.operation_log.purge_all(self.connection())
     }
 
+    /// Returns the `verified_by` value for the most recent operation that
+    /// modified the given note, or an empty string if none found.
+    pub fn get_note_verified_by(&self, note_id: &str) -> Result<String> {
+        use rusqlite::OptionalExtension;
+        let conn = self.connection();
+        let result: Option<String> = conn
+            .query_row(
+                "SELECT COALESCE(verified_by, '') FROM operations \
+                 WHERE operation_data LIKE '%\"note_id\":\"' || ?1 || '\"%' \
+                 ORDER BY timestamp_wall_ms DESC, timestamp_counter DESC, timestamp_node_id DESC \
+                 LIMIT 1",
+                [note_id],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(KrillnotesError::Database)?;
+        Ok(result.unwrap_or_default())
+    }
+
     /// Clears all registered schemas/hooks and re-executes enabled scripts from the DB in order.
     ///
     /// Returns any errors that occurred during loading (e.g. schema collisions, Rhai errors).

--- a/krillnotes-core/src/core/workspace/sync.rs
+++ b/krillnotes-core/src/core/workspace/sync.rs
@@ -9,6 +9,7 @@
 use super::*;
 use crate::core::peer_registry::SyncPeer;
 use crate::core::sync::channel::{ChannelType, PeerSyncInfo};
+use base64::Engine as _;
 
 impl Workspace {
     // ── Snapshot (peer sync) ───────────────────────────────────────
@@ -207,6 +208,8 @@ impl Workspace {
         op: Operation,
         received_from_peer: &str,
         attachment_blobs: &[(String, Vec<u8>)],
+        verified_by: Option<&str>,
+        sender_identity: &str,
     ) -> Result<bool> {
         // 1. Skip local-only retracts — they must never cross device boundaries.
         if matches!(
@@ -229,7 +232,55 @@ impl Workspace {
         // 2. Advance the local HLC by observing the incoming timestamp.
         self.hlc.observe(op.timestamp());
 
-        // 3. Insert into the operations log with synced = 1.
+        // 3. Per-op verification — reject ops that fail signature or vouch checks.
+        let author_key = op.author_key();
+        let resolved_verified_by: String = if author_key.is_empty() {
+            // Ops with no author key (RetractOperation) — accept only if vouched
+            match verified_by {
+                Some(vb) if vb == sender_identity => sender_identity.to_string(),
+                _ => {
+                    log::warn!(target: "krillnotes::sync",
+                        "rejecting op {} — no author key and not vouched by sender",
+                        op.operation_id());
+                    return Ok(false);
+                }
+            }
+        } else if author_key == sender_identity {
+            // Sender-authored: verify the original Ed25519 signature
+            let vk_bytes = base64::engine::general_purpose::STANDARD
+                .decode(sender_identity)
+                .map_err(|e| KrillnotesError::Swarm(format!("bad sender identity: {e}")))?;
+            let vk_arr: [u8; 32] = vk_bytes
+                .try_into()
+                .map_err(|_| KrillnotesError::Swarm("sender identity wrong length".into()))?;
+            let vk = ed25519_dalek::VerifyingKey::from_bytes(&vk_arr)
+                .map_err(|e| KrillnotesError::Swarm(format!("invalid sender key: {e}")))?;
+
+            if !op.verify(&vk) {
+                log::warn!(target: "krillnotes::sync",
+                    "rejecting op {} — sender-authored but signature invalid",
+                    op.operation_id());
+                return Ok(false);
+            }
+            sender_identity.to_string()
+        } else if let Some(vb) = verified_by {
+            // Relayed op with vouch — sender must be the voucher
+            if vb != sender_identity {
+                log::warn!(target: "krillnotes::sync",
+                    "rejecting op {} — verified_by doesn't match sender",
+                    op.operation_id());
+                return Ok(false);
+            }
+            sender_identity.to_string()
+        } else {
+            // Relayed op with no vouch — reject
+            log::warn!(target: "krillnotes::sync",
+                "rejecting op {} — relayed without vouching",
+                op.operation_id());
+            return Ok(false);
+        };
+
+        // 4. Insert into the operations log with synced = 1.
         //    INSERT OR IGNORE gives 0 changed rows if the operation_id already exists.
         let op_json = serde_json::to_string(&op)?;
         let ts = op.timestamp();
@@ -240,8 +291,8 @@ impl Workspace {
             let rows = tx.execute(
                 "INSERT OR IGNORE INTO operations \
                  (operation_id, timestamp_wall_ms, timestamp_counter, timestamp_node_id, \
-                  device_id, operation_type, operation_data, synced, received_from_peer) \
-                 VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?)",
+                  device_id, operation_type, operation_data, synced, received_from_peer, verified_by) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?)",
                 rusqlite::params![
                     op.operation_id(),
                     ts.wall_ms as i64,
@@ -251,19 +302,20 @@ impl Workspace {
                     op_type,
                     op_json,
                     received_from_peer,
+                    &resolved_verified_by,
                 ],
             )?;
             tx.commit()?;
             rows
         };
 
-        // 4. Duplicate — already applied.
+        // 5. Duplicate — already applied.
         if rows == 0 {
             log::debug!(target: "krillnotes::sync", "duplicate operation {}, skipping", op.operation_id());
             return Ok(false);
         }
 
-        // 5. Apply the state change to working tables.
+        // 6. Apply the state change to working tables.
         let mut scripts_changed = false;
         // (attachment_id, note_id, filename, mime_type, blob)
         let mut pending_attachment: Option<(String, String, String, Option<String>, Vec<u8>)> =

--- a/krillnotes-core/src/core/workspace/sync.rs
+++ b/krillnotes-core/src/core/workspace/sync.rs
@@ -196,6 +196,110 @@ impl Workspace {
         Ok(ops)
     }
 
+    /// Like [`operations_since`], but also returns the `verified_by` column for each op.
+    ///
+    /// Used by `generate_delta` to decide per-operation vouching:
+    /// - Self-authored ops → `verified_by: None` (receiver verifies signature directly)
+    /// - Previously verified/vouched ops → re-vouch with sender's identity
+    /// - Unverified ops → filtered out (not included in delta)
+    pub fn operations_since_with_verified_by(
+        &self,
+        since_op_id: Option<&str>,
+        exclude_device_id: &str,
+    ) -> Result<Vec<(Operation, String)>> {
+        let conn = self.storage.connection();
+
+        let rows: Vec<(String, String)> = if let Some(op_id) = since_op_id {
+            let hlc_row: Option<(i64, i64, i64)> = conn
+                .query_row(
+                    "SELECT timestamp_wall_ms, timestamp_counter, timestamp_node_id \
+                     FROM operations WHERE operation_id = ?1",
+                    [op_id],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                )
+                .optional()
+                .map_err(KrillnotesError::Database)?;
+
+            if let Some((wall_ms, counter, node_id)) = hlc_row {
+                let mut stmt = conn.prepare(
+                    "SELECT operation_data, COALESCE(verified_by, '') FROM operations \
+                     WHERE ((timestamp_wall_ms > ?1) \
+                        OR  (timestamp_wall_ms = ?1 AND timestamp_counter > ?2) \
+                        OR  (timestamp_wall_ms = ?1 AND timestamp_counter = ?2 \
+                             AND timestamp_node_id > ?3)) \
+                     AND device_id != ?4 \
+                     AND (received_from_peer IS NULL OR received_from_peer != ?5) \
+                     ORDER BY timestamp_wall_ms ASC, timestamp_counter ASC, \
+                              timestamp_node_id ASC",
+                )?;
+                let rows = stmt
+                    .query_map(
+                        rusqlite::params![
+                            wall_ms,
+                            counter,
+                            node_id,
+                            exclude_device_id,
+                            exclude_device_id
+                        ],
+                        |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+                    )?
+                    .collect::<rusqlite::Result<Vec<_>>>()
+                    .map_err(KrillnotesError::Database)?;
+                rows
+            } else {
+                let mut stmt = conn.prepare(
+                    "SELECT operation_data, COALESCE(verified_by, '') FROM operations \
+                     WHERE device_id != ?1 \
+                     AND (received_from_peer IS NULL OR received_from_peer != ?2) \
+                     ORDER BY timestamp_wall_ms ASC, timestamp_counter ASC, \
+                              timestamp_node_id ASC",
+                )?;
+                let rows = stmt
+                    .query_map(
+                        rusqlite::params![exclude_device_id, exclude_device_id],
+                        |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+                    )?
+                    .collect::<rusqlite::Result<Vec<_>>>()
+                    .map_err(KrillnotesError::Database)?;
+                rows
+            }
+        } else {
+            let mut stmt = conn.prepare(
+                "SELECT operation_data, COALESCE(verified_by, '') FROM operations \
+                 WHERE device_id != ?1 \
+                 AND (received_from_peer IS NULL OR received_from_peer != ?2) \
+                 ORDER BY timestamp_wall_ms ASC, timestamp_counter ASC, \
+                          timestamp_node_id ASC",
+            )?;
+            let rows = stmt
+                .query_map(
+                    rusqlite::params![exclude_device_id, exclude_device_id],
+                    |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+                )?
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .map_err(KrillnotesError::Database)?;
+            rows
+        };
+
+        let mut ops: Vec<(Operation, String)> = rows
+            .into_iter()
+            .filter_map(|(json, vb)| serde_json::from_str(&json).ok().map(|op| (op, vb)))
+            .collect();
+
+        // Filter local-only retracts (propagate = false)
+        ops.retain(|(op, _)| {
+            !matches!(
+                op,
+                Operation::RetractOperation {
+                    propagate: false,
+                    ..
+                }
+            )
+        });
+
+        Ok(ops)
+    }
+
     /// Apply a single operation received from a remote peer.
     ///
     /// Returns `Ok(true)` if the operation was inserted and applied to the working tables,

--- a/krillnotes-core/src/core/workspace/tests.rs
+++ b/krillnotes-core/src/core/workspace/tests.rs
@@ -6014,3 +6014,45 @@ fn test_m6_set_note_checked_stores_seconds_timestamp() {
         note.modified_at
     );
 }
+
+#[test]
+fn test_self_authored_ops_have_verified_by() {
+    let temp = NamedTempFile::new().unwrap();
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(&[1u8; 32]);
+    let expected_pubkey = {
+        use base64::Engine as _;
+        let pubkey = ed25519_dalek::VerifyingKey::from(&signing_key);
+        base64::engine::general_purpose::STANDARD.encode(pubkey.as_bytes())
+    };
+
+    let mut ws = Workspace::create(
+        temp.path(),
+        "",
+        "test-identity",
+        signing_key,
+        test_gate(),
+        None,
+    )
+    .unwrap();
+
+    // Create a child note to generate an explicit CreateNote op.
+    let root_id = ws.list_all_notes().unwrap()[0].id.clone();
+    let child_id = ws
+        .create_note(&root_id, AddPosition::AsChild, "TextNote")
+        .unwrap();
+
+    // Query the operations table for the child's CreateNote op.
+    let verified_by: String = ws
+        .connection()
+        .query_row(
+            "SELECT verified_by FROM operations WHERE operation_type = 'CreateNote' AND operation_data LIKE ?",
+            [format!("%{}%", child_id)],
+            |row| row.get(0),
+        )
+        .unwrap();
+
+    assert_eq!(
+        verified_by, expected_pubkey,
+        "Self-authored operations should have verified_by = identity pubkey"
+    );
+}

--- a/krillnotes-core/src/core/workspace/tests.rs
+++ b/krillnotes-core/src/core/workspace/tests.rs
@@ -1,4 +1,3 @@
-
 use super::*;
 use crate::core::contact::{ContactManager, TrustLevel};
 use crate::core::permission::{AllowAllGate, PermissionGate};
@@ -5011,10 +5010,22 @@ fn test_operations_since_filters_local_retract() {
 
 // ── apply_incoming_operation tests ──────────────────────────────────────
 
-/// Helper: build a minimal CreateNote operation for testing.
+/// A test signing key used by `make_create_note_op` and related helpers.
+fn test_signing_key() -> ed25519_dalek::SigningKey {
+    ed25519_dalek::SigningKey::from_bytes(&[42u8; 32])
+}
+
+/// Base64 public key corresponding to `test_signing_key()`.
+fn test_sender_identity() -> String {
+    use base64::Engine as _;
+    let vk = ed25519_dalek::VerifyingKey::from(&test_signing_key());
+    base64::engine::general_purpose::STANDARD.encode(vk.as_bytes())
+}
+
+/// Helper: build a minimal CreateNote operation for testing, signed with `test_signing_key()`.
 fn make_create_note_op(op_id: &str, note_id: &str, device_id: &str, wall_ms: u64) -> Operation {
     use crate::core::hlc::HlcTimestamp;
-    Operation::CreateNote {
+    let mut op = Operation::CreateNote {
         operation_id: op_id.to_string(),
         timestamp: HlcTimestamp {
             wall_ms,
@@ -5030,7 +5041,9 @@ fn make_create_note_op(op_id: &str, note_id: &str, device_id: &str, wall_ms: u64
         fields: BTreeMap::new(),
         created_by: String::new(),
         signature: String::new(),
-    }
+    };
+    op.sign(&test_signing_key());
+    op
 }
 
 #[test]
@@ -5048,7 +5061,9 @@ fn test_apply_incoming_create_note() {
 
     let op = make_create_note_op("op-remote-1", "note-remote-1", "remote-device", 1_000_000);
 
-    let applied = ws.apply_incoming_operation(op, "test-peer", &[]).unwrap();
+    let applied = ws
+        .apply_incoming_operation(op, "test-peer", &[], None, &test_sender_identity())
+        .unwrap();
     assert!(applied, "first application must return true");
 
     // The note must exist in the working table.
@@ -5089,12 +5104,15 @@ fn test_apply_incoming_duplicate_is_idempotent() {
 
     let op = make_create_note_op("op-dup-1", "note-dup-1", "remote-device", 2_000_000);
 
+    let sender_id = test_sender_identity();
     let first = ws
-        .apply_incoming_operation(op.clone(), "test-peer", &[])
+        .apply_incoming_operation(op.clone(), "test-peer", &[], None, &sender_id)
         .unwrap();
     assert!(first, "first call must return true");
 
-    let second = ws.apply_incoming_operation(op, "test-peer", &[]).unwrap();
+    let second = ws
+        .apply_incoming_operation(op, "test-peer", &[], None, &sender_id)
+        .unwrap();
     assert!(!second, "duplicate must return false");
 
     // Only one row must exist.
@@ -5139,7 +5157,9 @@ fn test_apply_incoming_retract_propagate_false_skipped() {
         propagate: false,
     };
 
-    let applied = ws.apply_incoming_operation(op, "test-peer", &[]).unwrap();
+    let applied = ws
+        .apply_incoming_operation(op, "test-peer", &[], None, &test_sender_identity())
+        .unwrap();
     assert!(!applied, "local-only retract must be skipped");
 
     // Nothing must have been inserted into operations.
@@ -5175,7 +5195,9 @@ fn test_apply_incoming_hlc_advances() {
         "remote-device",
         far_future_ms,
     );
-    ws.apply_incoming_operation(op, "test-peer", &[]).unwrap();
+    let sender_id = test_sender_identity();
+    ws.apply_incoming_operation(op, "test-peer", &[], None, &sender_id)
+        .unwrap();
 
     // Now create a local note — its HLC timestamp must be >= far_future_ms.
     let _root = ws.list_all_notes().unwrap()[0].clone();
@@ -5202,7 +5224,8 @@ fn test_apply_incoming_hlc_advances() {
         "remote-device",
         far_future_ms + 1,
     );
-    ws.apply_incoming_operation(op2, "test-peer", &[]).unwrap();
+    ws.apply_incoming_operation(op2, "test-peer", &[], None, &sender_id)
+        .unwrap();
 
     let stored2: i64 = ws
         .connection()
@@ -5440,8 +5463,9 @@ fn test_apply_incoming_script_op_from_owner_applied() {
     };
     op.sign(&key);
 
+    let sender_id = workspace.identity_pubkey().to_string();
     let applied = workspace
-        .apply_incoming_operation(op, "test-peer", &[])
+        .apply_incoming_operation(op, "test-peer", &[], None, &sender_id)
         .unwrap();
     assert!(applied);
 }
@@ -5476,20 +5500,249 @@ fn test_apply_incoming_script_op_from_non_owner_skipped() {
         source_code: "// @name: Evil Script\n".to_string(),
         load_order: 99,
         enabled: true,
-        created_by: pubkey_b,
+        created_by: pubkey_b.clone(),
         signature: String::new(),
     };
     op.sign(&key_b);
 
     // Op is logged (returns true) but script should NOT appear in user_scripts
     let result = workspace
-        .apply_incoming_operation(op, "test-peer", &[])
+        .apply_incoming_operation(op, "test-peer", &[], None, &pubkey_b)
         .unwrap();
     assert!(result); // Logged to operations table
 
     // Verify the script was NOT applied to the working table
     let scripts = workspace.list_user_scripts().unwrap();
     assert!(!scripts.iter().any(|s| s.id == script_id));
+}
+
+// ── Per-op verification tests ─────────────────────────────────────────
+
+#[test]
+fn test_verify_sender_authored_op_valid_signature() {
+    let temp = NamedTempFile::new().unwrap();
+    let ws_key = ed25519_dalek::SigningKey::from_bytes(&[1u8; 32]);
+    let mut ws =
+        Workspace::create(temp.path(), "", "ws-device", ws_key, test_gate(), None).unwrap();
+
+    // Create and sign an op with a known key
+    let sender_key = ed25519_dalek::SigningKey::from_bytes(&[5u8; 32]);
+    let sender_pubkey = {
+        use base64::Engine as _;
+        base64::engine::general_purpose::STANDARD.encode(sender_key.verifying_key().as_bytes())
+    };
+
+    let mut op = make_create_note_op("verify-ok-1", "note-verify-1", "remote-dev", 5_000_000);
+    op.sign(&sender_key);
+
+    let applied = ws
+        .apply_incoming_operation(op, "test-peer", &[], None, &sender_pubkey)
+        .unwrap();
+    assert!(
+        applied,
+        "sender-authored op with valid signature must be accepted"
+    );
+}
+
+#[test]
+fn test_verify_sender_authored_op_tampered_rejected() {
+    let temp = NamedTempFile::new().unwrap();
+    let ws_key = ed25519_dalek::SigningKey::from_bytes(&[1u8; 32]);
+    let mut ws =
+        Workspace::create(temp.path(), "", "ws-device", ws_key, test_gate(), None).unwrap();
+
+    let sender_key = ed25519_dalek::SigningKey::from_bytes(&[5u8; 32]);
+    let sender_pubkey = {
+        use base64::Engine as _;
+        base64::engine::general_purpose::STANDARD.encode(sender_key.verifying_key().as_bytes())
+    };
+
+    // Sign the op, then tamper with the title
+    let mut op = Operation::CreateNote {
+        operation_id: "verify-tamper-1".to_string(),
+        timestamp: crate::core::hlc::HlcTimestamp {
+            wall_ms: 6_000_000,
+            counter: 0,
+            node_id: 42,
+        },
+        device_id: "remote-dev".to_string(),
+        note_id: "note-tamper-1".to_string(),
+        parent_id: None,
+        position: 0.0,
+        schema: "TextNote".to_string(),
+        title: "Original Title".to_string(),
+        fields: BTreeMap::new(),
+        created_by: String::new(),
+        signature: String::new(),
+    };
+    op.sign(&sender_key);
+
+    // Tamper: change the title after signing
+    if let Operation::CreateNote { ref mut title, .. } = op {
+        *title = "Tampered Title".to_string();
+    }
+
+    let applied = ws
+        .apply_incoming_operation(op, "test-peer", &[], None, &sender_pubkey)
+        .unwrap();
+    assert!(!applied, "tampered op must be rejected (signature invalid)");
+}
+
+#[test]
+fn test_verify_vouched_relayed_op_accepted() {
+    let temp = NamedTempFile::new().unwrap();
+    let ws_key = ed25519_dalek::SigningKey::from_bytes(&[1u8; 32]);
+    let mut ws =
+        Workspace::create(temp.path(), "", "ws-device", ws_key, test_gate(), None).unwrap();
+
+    // Op authored by key_a, relayed (vouched) by key_b
+    let key_a = ed25519_dalek::SigningKey::from_bytes(&[10u8; 32]);
+    let key_b = ed25519_dalek::SigningKey::from_bytes(&[11u8; 32]);
+    let pubkey_b = {
+        use base64::Engine as _;
+        base64::engine::general_purpose::STANDARD.encode(key_b.verifying_key().as_bytes())
+    };
+
+    let mut op = make_create_note_op("relay-vouch-1", "note-relay-1", "dev-a", 7_000_000);
+    op.sign(&key_a); // author is key_a
+
+    // Sender is key_b, vouching for the op
+    let applied = ws
+        .apply_incoming_operation(op, "test-peer", &[], Some(&pubkey_b), &pubkey_b)
+        .unwrap();
+    assert!(applied, "relayed op with valid vouch must be accepted");
+}
+
+#[test]
+fn test_verify_unvouched_relayed_op_rejected() {
+    let temp = NamedTempFile::new().unwrap();
+    let ws_key = ed25519_dalek::SigningKey::from_bytes(&[1u8; 32]);
+    let mut ws =
+        Workspace::create(temp.path(), "", "ws-device", ws_key, test_gate(), None).unwrap();
+
+    // Op authored by key_a, sent by key_b without vouch
+    let key_a = ed25519_dalek::SigningKey::from_bytes(&[10u8; 32]);
+    let key_b = ed25519_dalek::SigningKey::from_bytes(&[11u8; 32]);
+    let pubkey_b = {
+        use base64::Engine as _;
+        base64::engine::general_purpose::STANDARD.encode(key_b.verifying_key().as_bytes())
+    };
+
+    let mut op = make_create_note_op("relay-novouch-1", "note-relay-2", "dev-a", 8_000_000);
+    op.sign(&key_a); // author is key_a
+
+    // Sender is key_b, but no vouch
+    let applied = ws
+        .apply_incoming_operation(op, "test-peer", &[], None, &pubkey_b)
+        .unwrap();
+    assert!(!applied, "relayed op without vouch must be rejected");
+}
+
+#[test]
+fn test_verify_vouch_mismatch_rejected() {
+    let temp = NamedTempFile::new().unwrap();
+    let ws_key = ed25519_dalek::SigningKey::from_bytes(&[1u8; 32]);
+    let mut ws =
+        Workspace::create(temp.path(), "", "ws-device", ws_key, test_gate(), None).unwrap();
+
+    let key_a = ed25519_dalek::SigningKey::from_bytes(&[10u8; 32]);
+    let key_b = ed25519_dalek::SigningKey::from_bytes(&[11u8; 32]);
+    let key_c = ed25519_dalek::SigningKey::from_bytes(&[12u8; 32]);
+    let pubkey_b = {
+        use base64::Engine as _;
+        base64::engine::general_purpose::STANDARD.encode(key_b.verifying_key().as_bytes())
+    };
+    let pubkey_c = {
+        use base64::Engine as _;
+        base64::engine::general_purpose::STANDARD.encode(key_c.verifying_key().as_bytes())
+    };
+
+    let mut op = make_create_note_op("relay-mismatch-1", "note-mismatch", "dev-a", 9_000_000);
+    op.sign(&key_a);
+
+    // verified_by claims key_b but sender is key_c — mismatch
+    let applied = ws
+        .apply_incoming_operation(op, "test-peer", &[], Some(&pubkey_b), &pubkey_c)
+        .unwrap();
+    assert!(!applied, "vouch from non-sender must be rejected");
+}
+
+#[test]
+fn test_verify_retract_op_vouched_accepted() {
+    use crate::core::hlc::HlcTimestamp;
+    use crate::RetractInverse;
+
+    let temp = NamedTempFile::new().unwrap();
+    let ws_key = ed25519_dalek::SigningKey::from_bytes(&[1u8; 32]);
+    let mut ws =
+        Workspace::create(temp.path(), "", "ws-device", ws_key, test_gate(), None).unwrap();
+
+    let sender_key = ed25519_dalek::SigningKey::from_bytes(&[5u8; 32]);
+    let sender_pubkey = {
+        use base64::Engine as _;
+        base64::engine::general_purpose::STANDARD.encode(sender_key.verifying_key().as_bytes())
+    };
+
+    // RetractOperation (propagate: true) has empty author_key — must be vouched
+    let op = Operation::RetractOperation {
+        operation_id: "retract-vouch-1".to_string(),
+        timestamp: HlcTimestamp {
+            wall_ms: 10_000_000,
+            counter: 0,
+            node_id: 99,
+        },
+        device_id: "remote-device".to_string(),
+        retracted_ids: vec!["some-op".to_string()],
+        inverse: RetractInverse::DeleteNote {
+            note_id: "fake-note".to_string(),
+        },
+        propagate: true,
+    };
+
+    let applied = ws
+        .apply_incoming_operation(op, "test-peer", &[], Some(&sender_pubkey), &sender_pubkey)
+        .unwrap();
+    assert!(applied, "propagating retract with vouch must be accepted");
+}
+
+#[test]
+fn test_verify_retract_op_unvouched_rejected() {
+    use crate::core::hlc::HlcTimestamp;
+    use crate::RetractInverse;
+
+    let temp = NamedTempFile::new().unwrap();
+    let ws_key = ed25519_dalek::SigningKey::from_bytes(&[1u8; 32]);
+    let mut ws =
+        Workspace::create(temp.path(), "", "ws-device", ws_key, test_gate(), None).unwrap();
+
+    let sender_key = ed25519_dalek::SigningKey::from_bytes(&[5u8; 32]);
+    let sender_pubkey = {
+        use base64::Engine as _;
+        base64::engine::general_purpose::STANDARD.encode(sender_key.verifying_key().as_bytes())
+    };
+
+    let op = Operation::RetractOperation {
+        operation_id: "retract-novouch-1".to_string(),
+        timestamp: HlcTimestamp {
+            wall_ms: 11_000_000,
+            counter: 0,
+            node_id: 99,
+        },
+        device_id: "remote-device".to_string(),
+        retracted_ids: vec!["some-op".to_string()],
+        inverse: RetractInverse::DeleteNote {
+            note_id: "fake-note".to_string(),
+        },
+        propagate: true,
+    };
+
+    let applied = ws
+        .apply_incoming_operation(op, "test-peer", &[], None, &sender_pubkey)
+        .unwrap();
+    assert!(
+        !applied,
+        "propagating retract without vouch must be rejected"
+    );
 }
 
 #[test]
@@ -5943,7 +6196,9 @@ fn test_apply_incoming_create_note_stores_seconds_timestamp() {
     let known_wall_ms: u64 = 1_714_000_000_000; // 2024-04-25 in milliseconds
     let expected_secs = (known_wall_ms / 1000) as i64;
 
-    let op = Operation::CreateNote {
+    let remote_key = test_signing_key();
+    let remote_id = test_sender_identity();
+    let mut op = Operation::CreateNote {
         operation_id: "sync-test-op-1".to_string(),
         timestamp: HlcTimestamp {
             wall_ms: known_wall_ms,
@@ -5957,11 +6212,13 @@ fn test_apply_incoming_create_note_stores_seconds_timestamp() {
         schema: "TextNote".to_string(),
         title: "Synced Note".to_string(),
         fields: BTreeMap::new(),
-        created_by: "remote-pubkey".to_string(),
+        created_by: String::new(),
         signature: String::new(),
     };
+    op.sign(&remote_key);
 
-    ws.apply_incoming_operation(op, "remote-peer", &[]).unwrap();
+    ws.apply_incoming_operation(op, "remote-peer", &[], None, &remote_id)
+        .unwrap();
 
     let row: (i64, i64) = ws
         .connection()

--- a/krillnotes-desktop/src-tauri/src/commands/notes.rs
+++ b/krillnotes-desktop/src-tauri/src/commands/notes.rs
@@ -407,7 +407,8 @@ pub fn list_operations(
         })?;
 
     // Resolve raw base64 public keys to display names where possible.
-    let mut resolved_indices = vec![false; summaries.len()];
+    let mut resolved_author = vec![false; summaries.len()];
+    let mut resolved_vb = vec![false; summaries.len()];
 
     // Pass 1: resolve via identity_manager, then drop the lock.
     {
@@ -416,7 +417,13 @@ pub fn list_operations(
             if !summary.author_key.is_empty() {
                 if let Some(name) = identity_manager.lookup_display_name(&summary.author_key) {
                     summary.author_key = name;
-                    resolved_indices[i] = true;
+                    resolved_author[i] = true;
+                }
+            }
+            if !summary.verified_by.is_empty() {
+                if let Some(name) = identity_manager.lookup_display_name(&summary.verified_by) {
+                    summary.verified_by = name;
+                    resolved_vb[i] = true;
                 }
             }
         }
@@ -426,19 +433,31 @@ pub fn list_operations(
     {
         let contact_managers = state.contact_managers.lock().expect("Mutex poisoned");
         for (i, summary) in summaries.iter_mut().enumerate() {
-            if resolved_indices[i] || summary.author_key.is_empty() {
-                continue;
-            }
-            let mut resolved = false;
-            for cm in contact_managers.values() {
-                if let Ok(Some(contact)) = cm.find_by_public_key(&summary.author_key) {
-                    summary.author_key = contact.display_name().to_string();
-                    resolved = true;
-                    break;
+            if !resolved_author[i] && !summary.author_key.is_empty() {
+                let mut resolved = false;
+                for cm in contact_managers.values() {
+                    if let Ok(Some(contact)) = cm.find_by_public_key(&summary.author_key) {
+                        summary.author_key = contact.display_name().to_string();
+                        resolved = true;
+                        break;
+                    }
+                }
+                if !resolved {
+                    summary.author_key = summary.author_key.chars().take(8).collect();
                 }
             }
-            if !resolved {
-                summary.author_key = summary.author_key.chars().take(8).collect();
+            if !resolved_vb[i] && !summary.verified_by.is_empty() {
+                let mut resolved = false;
+                for cm in contact_managers.values() {
+                    if let Ok(Some(contact)) = cm.find_by_public_key(&summary.verified_by) {
+                        summary.verified_by = contact.display_name().to_string();
+                        resolved = true;
+                        break;
+                    }
+                }
+                if !resolved {
+                    summary.verified_by = summary.verified_by.chars().take(8).collect();
+                }
             }
         }
     }
@@ -485,6 +504,43 @@ pub fn purge_operations(
             log::error!("purge_operations failed: {e}");
             e.to_string()
         })
+}
+
+/// Returns the resolved display name of the identity that verified the most
+/// recent operation targeting `note_id`.  Empty string if no match.
+#[tauri::command]
+pub fn get_note_verified_by(
+    window: tauri::Window,
+    state: State<'_, AppState>,
+    note_id: String,
+) -> std::result::Result<String, String> {
+    let label = window.label();
+    let workspaces = state.workspaces.lock().expect("Mutex poisoned");
+    let ws = workspaces.get(label).ok_or("No workspace open")?;
+    let raw_key = ws.get_note_verified_by(&note_id).map_err(|e| e.to_string())?;
+
+    if raw_key.is_empty() {
+        return Ok(String::new());
+    }
+
+    // Resolve to display name
+    if let Some(name) = state
+        .identity_manager
+        .lock()
+        .expect("Mutex poisoned")
+        .lookup_display_name(&raw_key)
+    {
+        return Ok(name);
+    }
+
+    let contact_managers = state.contact_managers.lock().expect("Mutex poisoned");
+    for cm in contact_managers.values() {
+        if let Ok(Some(contact)) = cm.find_by_public_key(&raw_key) {
+            return Ok(contact.display_name().to_string());
+        }
+    }
+
+    Ok(raw_key.chars().take(8).collect())
 }
 
 // ── Undo / Redo commands ──────────────────────────────────────────

--- a/krillnotes-desktop/src-tauri/src/commands/receive_poll.rs
+++ b/krillnotes-desktop/src-tauri/src/commands/receive_poll.rs
@@ -568,6 +568,8 @@ pub async fn poll_receive_workspace(
         struct OpEntry {
             op: krillnotes_core::core::operation::Operation,
             sender_device_id: String,
+            sender_public_key: String,
+            verified_by: Option<String>,
             attachment_blobs: Arc<Vec<(String, Vec<u8>)>>,
         }
 
@@ -575,10 +577,13 @@ pub async fn poll_receive_workspace(
             .iter()
             .flat_map(|dd| {
                 let sender = dd.parsed.sender_device_id.clone();
+                let sender_pk = dd.parsed.sender_public_key.clone();
                 let blobs = Arc::new(dd.parsed.attachment_blobs.clone());
                 dd.parsed.delta_operations.iter().map(move |delta_op| OpEntry {
                     op: delta_op.op.clone(),
                     sender_device_id: sender.clone(),
+                    sender_public_key: sender_pk.clone(),
+                    verified_by: delta_op.verified_by.clone(),
                     attachment_blobs: Arc::clone(&blobs),
                 })
             })
@@ -633,7 +638,7 @@ pub async fn poll_receive_workspace(
                     .map_err(|e| e.to_string())?;
             }
 
-            match workspace.apply_incoming_operation(entry.op.clone(), &entry.sender_device_id, &entry.attachment_blobs) {
+            match workspace.apply_incoming_operation(entry.op.clone(), &entry.sender_device_id, &entry.attachment_blobs, entry.verified_by.as_deref(), &entry.sender_public_key) {
                 Ok(true) => {
                     log::debug!(
                         "poll_receive_workspace: applied op {} from {}",

--- a/krillnotes-desktop/src-tauri/src/commands/receive_poll.rs
+++ b/krillnotes-desktop/src-tauri/src/commands/receive_poll.rs
@@ -576,8 +576,8 @@ pub async fn poll_receive_workspace(
             .flat_map(|dd| {
                 let sender = dd.parsed.sender_device_id.clone();
                 let blobs = Arc::new(dd.parsed.attachment_blobs.clone());
-                dd.parsed.operations.iter().map(move |op| OpEntry {
-                    op: op.clone(),
+                dd.parsed.delta_operations.iter().map(move |delta_op| OpEntry {
+                    op: delta_op.op.clone(),
                     sender_device_id: sender.clone(),
                     attachment_blobs: Arc::clone(&blobs),
                 })

--- a/krillnotes-desktop/src-tauri/src/lib.rs
+++ b/krillnotes-desktop/src-tauri/src/lib.rs
@@ -430,6 +430,7 @@ pub fn run() {
             list_operations,
             get_operation_detail,
             purge_operations,
+            get_note_verified_by,
             export_workspace_cmd,
             peek_import_cmd,
             execute_import,

--- a/krillnotes-desktop/src/components/InfoPanel.tsx
+++ b/krillnotes-desktop/src/components/InfoPanel.tsx
@@ -39,6 +39,7 @@ function InfoPanel({ selectedNote, onNoteUpdated, onDeleteRequest, requestEditMo
   const { t } = useTranslation();
   const [recentlyDeleted, setRecentlyDeleted] = useState<AttachmentMeta[]>([]);
   const [authorNames, setAuthorNames] = useState<{ createdBy: string | null; modifiedBy: string | null }>({ createdBy: null, modifiedBy: null });
+  const [verifiedBy, setVerifiedBy] = useState<string>('');
   const [roleInfo, setRoleInfo] = useState<EffectiveRoleInfo | null>(null);
   const [anchoredGrants, setAnchoredGrants] = useState<PermissionGrantRow[]>([]);
   const [inheritedGrants, setInheritedGrants] = useState<InheritedGrant[]>([]);
@@ -206,6 +207,13 @@ function InfoPanel({ selectedNote, onNoteUpdated, onDeleteRequest, requestEditMo
       modifiedBy ? invoke<string | null>('resolve_identity_name', { publicKey: modifiedBy }) : Promise.resolve(null),
     ]).then(([cb, mb]) => setAuthorNames({ createdBy: cb, modifiedBy: mb }));
   }, [selectedNote?.createdBy, selectedNote?.modifiedBy]);
+
+  useEffect(() => {
+    if (!selectedNote) { setVerifiedBy(''); return; }
+    invoke<string>('get_note_verified_by', { noteId: selectedNote.id })
+      .then(setVerifiedBy)
+      .catch(() => setVerifiedBy(''));
+  }, [selectedNote?.id, selectedNote?.modifiedAt]);
 
   useEffect(() => {
     if (!selectedNote) { setRoleInfo(null); return; }
@@ -713,6 +721,13 @@ function InfoPanel({ selectedNote, onNoteUpdated, onDeleteRequest, requestEditMo
             {formatTimestamp(selectedNote.modifiedAt)}
             {authorNames.modifiedBy && <span className="text-muted-foreground"> · {authorNames.modifiedBy}</span>}
           </dd>
+
+          {verifiedBy && (
+            <>
+              <dt className="text-sm font-medium text-muted-foreground self-start pt-0.5 whitespace-nowrap">{t('info.verifiedBy')}</dt>
+              <dd className="m-0 text-foreground text-sm">{verifiedBy}</dd>
+            </>
+          )}
 
           <dt className="text-sm font-medium text-muted-foreground self-start pt-0.5 whitespace-nowrap">{t('notes.id')}</dt>
           <dd className="m-0 text-foreground text-xs font-mono break-all">{selectedNote.id}</dd>

--- a/krillnotes-desktop/src/components/OperationsLogDialog.tsx
+++ b/krillnotes-desktop/src/components/OperationsLogDialog.tsx
@@ -34,7 +34,7 @@ function formatKey(key: string): string {
 }
 
 // Fields shown in the "metadata" section at the top of the detail panel.
-const METADATA_KEYS = new Set(['type', 'operation_id', 'device_id', 'timestamp']);
+const METADATA_KEYS = new Set(['type', 'operation_id', 'device_id', 'timestamp', 'verified_by']);
 
 // Operation fields that hold a public key identifying the author.
 const AUTHOR_KEY_FIELDS = new Set(['created_by', 'modified_by', 'deleted_by', 'moved_by', 'updated_by']);
@@ -91,10 +91,12 @@ function DetailValue({ fieldKey, value }: { fieldKey: string; value: unknown }) 
 function OperationDetailPanel({
   detail,
   resolvedAuthor,
+  resolvedVerifiedBy,
   onClose,
 }: {
   detail: Record<string, unknown>;
   resolvedAuthor: string;
+  resolvedVerifiedBy: string;
   onClose: () => void;
 }) {
   const { t } = useTranslation();
@@ -123,13 +125,21 @@ function OperationDetailPanel({
           <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1">{t('log.metadata')}</p>
           <dl className="space-y-1.5">
             {metaEntries.map(([k, v]) => (
-              k === 'type' ? null : (
+              k === 'type' || k === 'verified_by' ? null : (
                 <div key={k}>
                   <dt className="text-xs text-muted-foreground">{formatKey(k)}</dt>
                   <dd className="mt-0.5"><DetailValue fieldKey={k} value={v} /></dd>
                 </div>
               )
             ))}
+            <div>
+              <dt className="text-xs text-muted-foreground">{t('log.verifiedBy')}</dt>
+              <dd className="mt-0.5">
+                <span className="font-mono text-xs break-all">
+                  {resolvedVerifiedBy || '—'}
+                </span>
+              </dd>
+            </div>
           </dl>
         </section>
 
@@ -360,6 +370,7 @@ function OperationsLogDialog({ isOpen, onClose }: OperationsLogDialogProps) {
                       <th className="text-left px-4 py-2 font-medium text-muted-foreground">{t('log.dateTime')}</th>
                       <th className="text-left px-4 py-2 font-medium text-muted-foreground">{t('log.target')}</th>
                       <th className="text-left px-4 py-2 font-medium text-muted-foreground">{t('log.author')}</th>
+                      <th className="text-left px-4 py-2 font-medium text-muted-foreground">{t('log.verifiedBy')}</th>
                       <th className="text-right px-4 py-2 font-medium text-muted-foreground">{t('log.type')}</th>
                     </tr>
                   </thead>
@@ -385,6 +396,11 @@ function OperationsLogDialog({ isOpen, onClose }: OperationsLogDialogProps) {
                             {op.authorKey || '—'}
                           </span>
                         </td>
+                        <td className="px-4 py-2 whitespace-nowrap">
+                          <span className="text-xs font-mono text-muted-foreground">
+                            {op.verifiedBy || '—'}
+                          </span>
+                        </td>
                         <td className="px-4 py-2 text-right">
                           <span className="inline-block bg-muted text-muted-foreground rounded px-2 py-0.5 text-xs font-mono">
                             {op.operationType}
@@ -402,6 +418,7 @@ function OperationsLogDialog({ isOpen, onClose }: OperationsLogDialogProps) {
               <OperationDetailPanel
                 detail={opDetail}
                 resolvedAuthor={operations.find((op) => op.operationId === selectedOpId)?.authorKey ?? ''}
+                resolvedVerifiedBy={operations.find((op) => op.operationId === selectedOpId)?.verifiedBy ?? ''}
                 onClose={() => { setSelectedOpId(null); setOpDetail(null); }}
               />
             )}

--- a/krillnotes-desktop/src/i18n/locales/de.json
+++ b/krillnotes-desktop/src/i18n/locales/de.json
@@ -304,7 +304,8 @@
     "syncCount_other": "{{count}} Ereignisse",
     "syncBundleRejected": "Paket abgelehnt",
     "syncSignatureInvalid": "Signatur ungültig",
-    "syncSidecarMismatch": "Sidecar-Abweichung"
+    "syncSidecarMismatch": "Sidecar-Abweichung",
+    "verifiedBy": "Bestätigt von"
   },
   "empty": {
     "getStarted": "Verwende Datei > Neuer Arbeitsbereich oder Datei > Arbeitsbereich öffnen, um zu beginnen"
@@ -718,7 +719,8 @@
     "accessFromParent": "Zugriff vom übergeordneten Element gewährt",
     "shareSubtree": "Diesen Teilbaum teilen…",
     "revoke": "Widerrufen",
-    "via": "über"
+    "via": "über",
+    "verifiedBy": "Bestätigt von"
   },
   "share": {
     "title": "Teilbaum teilen",

--- a/krillnotes-desktop/src/i18n/locales/en.json
+++ b/krillnotes-desktop/src/i18n/locales/en.json
@@ -304,7 +304,8 @@
     "syncCount_other": "{{count}} events",
     "syncBundleRejected": "Bundle Rejected",
     "syncSignatureInvalid": "Signature Invalid",
-    "syncSidecarMismatch": "Sidecar Mismatch"
+    "syncSidecarMismatch": "Sidecar Mismatch",
+    "verifiedBy": "Verified by"
   },
   "empty": {
     "getStarted": "Use File > New Workspace or File > Open Workspace to get started"
@@ -718,7 +719,8 @@
     "accessFromParent": "Access from parent grants",
     "shareSubtree": "Share this subtree...",
     "revoke": "Revoke",
-    "via": "via"
+    "via": "via",
+    "verifiedBy": "Verified by"
   },
   "share": {
     "title": "Share subtree",

--- a/krillnotes-desktop/src/i18n/locales/es.json
+++ b/krillnotes-desktop/src/i18n/locales/es.json
@@ -304,7 +304,8 @@
     "syncCount_other": "{{count}} eventos",
     "syncBundleRejected": "Paquete rechazado",
     "syncSignatureInvalid": "Firma inválida",
-    "syncSidecarMismatch": "Discrepancia de sidecar"
+    "syncSidecarMismatch": "Discrepancia de sidecar",
+    "verifiedBy": "Verificado por"
   },
   "empty": {
     "getStarted": "Usa Archivo > Nuevo espacio de trabajo o Archivo > Abrir espacio de trabajo para empezar"
@@ -718,7 +719,8 @@
     "accessFromParent": "El acceso del padre otorga",
     "shareSubtree": "Compartir este subárbol…",
     "revoke": "Revocar",
-    "via": "vía"
+    "via": "vía",
+    "verifiedBy": "Verificado por"
   },
   "share": {
     "title": "Compartir subárbol",

--- a/krillnotes-desktop/src/i18n/locales/fr.json
+++ b/krillnotes-desktop/src/i18n/locales/fr.json
@@ -304,7 +304,8 @@
     "syncCount_other": "{{count}} événements",
     "syncBundleRejected": "Paquet rejeté",
     "syncSignatureInvalid": "Signature invalide",
-    "syncSidecarMismatch": "Décalage de sidecar"
+    "syncSidecarMismatch": "Décalage de sidecar",
+    "verifiedBy": "Vérifié par"
   },
   "empty": {
     "getStarted": "Utilisez Fichier > Nouvel espace de travail ou Fichier > Ouvrir un espace de travail pour commencer"
@@ -718,7 +719,8 @@
     "accessFromParent": "L'accès depuis le parent accorde",
     "shareSubtree": "Partager ce sous-arbre…",
     "revoke": "Révoquer",
-    "via": "via"
+    "via": "via",
+    "verifiedBy": "Vérifié par"
   },
   "share": {
     "title": "Partager le sous-arbre",

--- a/krillnotes-desktop/src/i18n/locales/ja.json
+++ b/krillnotes-desktop/src/i18n/locales/ja.json
@@ -304,7 +304,8 @@
     "syncCount_other": "{{count}} 件のイベント",
     "syncBundleRejected": "バンドル拒否",
     "syncSignatureInvalid": "署名無効",
-    "syncSidecarMismatch": "サイドカー不一致"
+    "syncSidecarMismatch": "サイドカー不一致",
+    "verifiedBy": "検証者"
   },
   "empty": {
     "getStarted": "ファイル > 新しいワークスペース または ファイル > ワークスペースを開く から始めてください"
@@ -718,7 +719,8 @@
     "accessFromParent": "親からのアクセス権限",
     "shareSubtree": "このサブツリーを共有…",
     "revoke": "取り消す",
-    "via": "経由"
+    "via": "経由",
+    "verifiedBy": "検証者"
   },
   "share": {
     "title": "サブツリーを共有",

--- a/krillnotes-desktop/src/i18n/locales/ko.json
+++ b/krillnotes-desktop/src/i18n/locales/ko.json
@@ -304,7 +304,8 @@
     "syncCount_other": "{{count}}개 이벤트",
     "syncBundleRejected": "번들 거부됨",
     "syncSignatureInvalid": "서명 무효",
-    "syncSidecarMismatch": "사이드카 불일치"
+    "syncSidecarMismatch": "사이드카 불일치",
+    "verifiedBy": "검증자"
   },
   "empty": {
     "getStarted": "파일 > 새 작업 공간 또는 파일 > 작업 공간 열기를 사용하여 시작하세요"
@@ -718,7 +719,8 @@
     "accessFromParent": "상위에서 상속된 접근 권한",
     "shareSubtree": "이 하위 트리 공유...",
     "revoke": "철회",
-    "via": "경유"
+    "via": "경유",
+    "verifiedBy": "검증자"
   },
   "share": {
     "title": "하위 트리 공유",

--- a/krillnotes-desktop/src/i18n/locales/zh.json
+++ b/krillnotes-desktop/src/i18n/locales/zh.json
@@ -304,7 +304,8 @@
     "syncCount_other": "{{count}} 个事件",
     "syncBundleRejected": "包已拒绝",
     "syncSignatureInvalid": "签名无效",
-    "syncSidecarMismatch": "附件不匹配"
+    "syncSidecarMismatch": "附件不匹配",
+    "verifiedBy": "验证者"
   },
   "empty": {
     "getStarted": "使用文件 > 新建工作区 或 文件 > 打开工作区 开始使用"
@@ -718,7 +719,8 @@
     "accessFromParent": "来自父级的访问权限授予",
     "shareSubtree": "共享此子树…",
     "revoke": "撤销",
-    "via": "通过"
+    "via": "通过",
+    "verifiedBy": "验证者"
   },
   "share": {
     "title": "共享子树",

--- a/krillnotes-desktop/src/types.ts
+++ b/krillnotes-desktop/src/types.ts
@@ -161,6 +161,7 @@ export interface OperationSummary {
   operationType: string;
   targetName: string;
   authorKey: string;        // first 8 chars of base64 key, or ""
+  verifiedBy: string;       // resolved display name of verifier, or ""
 }
 
 export interface AppSettings {


### PR DESCRIPTION
## Summary

Implements #150 — per-operation Ed25519 signature verification and transitive vouching for delta sync.

- **Schema:** Added `verified_by TEXT NOT NULL DEFAULT ''` column to `operations` table (with migration for existing DBs)
- **Self-authored ops:** `verified_by` is populated with the workspace identity pubkey on INSERT
- **Delta payload:** New `DeltaOperation` wrapper struct around `Operation` carrying optional `verified_by` metadata
- **Receiver verification:** `apply_incoming_operation` now verifies Ed25519 signatures for sender-authored ops and validates vouches for relayed ops. Unvouched relayed ops are rejected.
- **Sender vouching:** `generate_delta` queries `verified_by` from the DB and wraps ops with appropriate vouching metadata: self-authored ops get `None` (receiver verifies directly), previously-verified ops get re-vouched with sender's key
- **Full chain test:** A→B→C integration test verifying the complete trust chain

Closes #150

## Test plan

- [x] 626 tests pass (`cargo test -p krillnotes-core`)
- [x] TypeScript compiles (`npx tsc --noEmit`)
- [x] Code formatted (`cargo fmt --check`)
- [ ] Manual test: two-peer delta sync still works
- [ ] Manual test: three-peer relay chain propagates ops