### PR TITLE
fix: include is_checked in query context note maps

### DIFF
--- a/krillnotes-core/src/core/workspace/mod.rs
+++ b/krillnotes-core/src/core/workspace/mod.rs
@@ -1260,6 +1260,7 @@ fn note_to_rhai_dynamic(note: &Note) -> Dynamic {
     note_map.insert("title".into(), Dynamic::from(note.title.clone()));
     note_map.insert("fields".into(), Dynamic::from(fields_map));
     note_map.insert("tags".into(), Dynamic::from(tags_array));
+    note_map.insert("is_checked".into(), Dynamic::from(note.is_checked));
     Dynamic::from(note_map)
 }
 


### PR DESCRIPTION
## Summary

- `note_to_rhai_dynamic` was missing the `is_checked` field, so `get_children()`/`get_note()` results always had `is_checked` undefined
- Views filtering by checkbox state (e.g. task progress counters) got zero matches
- Adds the missing field to match `build_note_map` which already includes it

## Test plan

- [x] All 628 core tests pass
- [ ] Import a workspace with checked Task notes, verify `is_checked` is accessible from views using `get_children()`