### PR TITLE
fix: populate query context during on_save hooks

### DIFF
--- a/krillnotes-core/src/core/scripting/mod.rs
+++ b/krillnotes-core/src/core/scripting/mod.rs
@@ -280,6 +280,14 @@ impl ScriptRegistry {
     ///
     /// Returns [`KrillnotesError::Scripting`] if the hook throws a Rhai error
     /// or returns a malformed map.
+    pub fn set_query_context(&self, context: QueryContext) {
+        *self.query_context.lock().unwrap() = Some(context);
+    }
+
+    pub fn clear_query_context(&self) {
+        *self.query_context.lock().unwrap() = None;
+    }
+
     pub fn run_on_save_hook(
         &self,
         schema_name: &str,

--- a/krillnotes-core/src/core/workspace/hooks.rs
+++ b/krillnotes-core/src/core/workspace/hooks.rs
@@ -9,7 +9,7 @@
 use super::*;
 
 impl Workspace {
-    fn build_query_context(&self) -> Result<QueryContext> {
+    pub(crate) fn build_query_context(&self) -> Result<QueryContext> {
         let all_notes = self.list_all_notes()?;
         let mut notes_by_id: HashMap<String, Dynamic> = HashMap::new();
         let mut children_by_id: HashMap<String, Vec<Dynamic>> = HashMap::new();

--- a/krillnotes-core/src/core/workspace/notes.rs
+++ b/krillnotes-core/src/core/workspace/notes.rs
@@ -1837,13 +1837,17 @@ impl Workspace {
         // - hook called commit()        → apply effective_title / effective_fields
         // - hook called reject(…)       → return ValidationFailed error
         // - hook returned Map (old API) → hard Scripting error with migration message
-        let (title, fields) = match self.script_registry.run_on_save_hook(
+        let context = self.build_query_context()?;
+        self.script_registry.set_query_context(context);
+        let hook_result = self.script_registry.run_on_save_hook(
             &note_schema,
             note_id,
             &note_schema,
             &title,
             &fields,
-        )? {
+        );
+        self.script_registry.clear_query_context();
+        let (title, fields) = match hook_result? {
             None => (title, fields),
             Some(tx) if tx.committed => {
                 let pn = tx.pending_notes.get(note_id).ok_or_else(|| {


### PR DESCRIPTION
## Summary

- `on_save` hooks had no query context, so `get_note()` calls returned unit
- Hooks that resolve linked notes (e.g. Activity deriving its title from a linked Location/Transport/Stay) always fell through to fallback titles like "Untitled Activity"
- Now `build_query_context()` runs before the hook and clears after, matching the pattern used by view/hover hooks

## Test plan

- [x] All 628 core tests pass
- [ ] Create an Activity with a linked Location, save it, verify the title resolves to "09:00 — Location Name" instead of "Untitled Activity"