### PR TITLE
fix: wire click handler for note_link fields in Fields tab

### DIFF
--- a/krillnotes-desktop/src/components/InfoPanel.tsx
+++ b/krillnotes-desktop/src/components/InfoPanel.tsx
@@ -575,7 +575,14 @@ function InfoPanel({ selectedNote, onNoteUpdated, onDeleteRequest, requestEditMo
 
           if (visibleTopFields.length === 0 && visibleGroups.length === 0) return null;
           return (
-            <>
+            <div onClick={(e) => {
+              const noteLink = (e.target as Element).closest('.kn-view-link');
+              if (noteLink) {
+                e.preventDefault();
+                const id = noteLink.getAttribute('data-note-id');
+                if (id) onLinkNavigate(id);
+              }
+            }}>
               {visibleTopFields.length > 0 && (
                 <dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-1">
                   {visibleTopFields.map(field => (
@@ -623,7 +630,7 @@ function InfoPanel({ selectedNote, onNoteUpdated, onDeleteRequest, requestEditMo
                   </div>
                 );
               })}
-            </>
+            </div>
           );
         })())}
 


### PR DESCRIPTION
## Summary

- Clicking a note_link in the default Fields tab did nothing — the `<a class="kn-view-link">` had no click handler
- The delegated click handler only existed on the custom view HTML div, not the React-rendered Fields section
- Wraps the Fields tab content in a div with the same `.kn-view-link` delegation pattern

## Test plan

- [ ] Select a note with a note_link field (e.g. Activity linking to a Location)
- [ ] Switch to the Fields tab
- [ ] Click the linked note name — should navigate to that note